### PR TITLE
Typo

### DIFF
--- a/src/LinearAlgebra/Matrix.php
+++ b/src/LinearAlgebra/Matrix.php
@@ -15,7 +15,7 @@ class Matrix implements \ArrayAccess
     protected $m;
 
     /**
-     * Number of rows
+     * Number of columns
      * @var int
      */
     protected $n;


### PR DESCRIPTION
both n and m are described as the number of rows. Changed 'n' to columns.