### PR TITLE
Hanes-Woolf linearization

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,8 +864,13 @@ $parameters  = $regression->getParameters();
 $equation    = $regression->getEquation();
 $y           = $regression->evaluate(5);
 
-// Lineweaver-Burk method to fit an equation of the form: y = (V * x) / (K + x)
+// Fit data to the Michaelis–Menten model: y = (V * x) / (K + x)
+// Using Lineweaver-Burk linearization
 $regression  = new LineweaverBurk($points);
+
+//Or Hanes-Woolf linearization
+$regression  = new HanesWoolf($points);
+//Parameter access and evaluation proceeds the same for each
 $parameters  = $regression->getParameters();  // [V, K]
 $equation    = $regression->getEquation();    // y = Vx / (K + x)
 $y           = $regression->evaluate(5);

--- a/src/Statistics/Regression/HanesWoolf.php
+++ b/src/Statistics/Regression/HanesWoolf.php
@@ -1,6 +1,7 @@
 <?php
 namespace Math\Statistics\Regression;
 use Math\Functions\Map\Multi;
+
 /**
  * Use the Hanes-Woolf method to fit an equation of the form
  *       V * x
@@ -9,17 +10,10 @@ use Math\Functions\Map\Multi;
  *
  * The equation is linearized and fit using Least Squares
  */
-class LineweaverBurk extends Regression
+class HanesWoolf extends MichaelisMenten
 {
     use LeastSquares;
-    /**
-     * @var number V regression parameter
-     */
-    private $V;
-    /**
-     * @var number K regression parameter
-     */
-    private $K;
+
     /**
      * Calculate the regression parameters by least squares on linearized data
      * x / y = x / V + K / V
@@ -27,44 +21,11 @@ class LineweaverBurk extends Regression
     public function calculate()
     {
         // Linearize the relationship by dividing x by y
-        $y’ = Multi::disvide($this->xs, $this->ys);
+        $y’ = Multi::divide($this->xs, $this->ys);
         // Perform Least Squares Fit
         $parameters = $this->leastSquares($y’, $this->xs);
         // Translate the linearized parameters back.
         $this->V = 1 / $parameters['m'];
         $this->K = $parameters['b'] * $this->V;
-    }
-    /**
-     * Get regression parameters (V and K)
-     *
-     * @return array [ V => number, K => number ]
-     */
-    public function getParameters(): array
-    {
-        return [
-            'V' => $this->V,
-            'K' => $this->K,
-        ];
-    }
-    /**
-     * Get regression equation (y = V * X / (K + X))
-     *
-     * @return string
-     */
-    public function getEquation(): string
-    {
-        return sprintf('y = %fx/(%f+x)', $this->V, $this->K);
-    }
-   /**
-    * Evaluate the equation using the regression parameters
-    * y = V * X / (K + X)
-    *
-    * @param number $x
-    *
-    * @return number y evaluated
-    */
-    public function evaluate($x)
-    {
-        return ($this->V * $x) / ($this->K + $x);
     }
 }

--- a/src/Statistics/Regression/HanesWoolf.php
+++ b/src/Statistics/Regression/HanesWoolf.php
@@ -1,0 +1,70 @@
+<?php
+namespace Math\Statistics\Regression;
+use Math\Functions\Map\Multi;
+/**
+ * Use the Hanes-Woolf method to fit an equation of the form
+ *       V * x
+ * y = ----------
+ *       K + x
+ *
+ * The equation is linearized and fit using Least Squares
+ */
+class LineweaverBurk extends Regression
+{
+    use LeastSquares;
+    /**
+     * @var number V regression parameter
+     */
+    private $V;
+    /**
+     * @var number K regression parameter
+     */
+    private $K;
+    /**
+     * Calculate the regression parameters by least squares on linearized data
+     * x / y = x / V + K / V
+     */
+    public function calculate()
+    {
+        // Linearize the relationship by dividing x by y
+        $y’ = Multi::disvide($this->xs, $this->ys);
+        // Perform Least Squares Fit
+        $parameters = $this->leastSquares($y’, $this->xs);
+        // Translate the linearized parameters back.
+        $this->V = 1 / $parameters['m'];
+        $this->K = $parameters['b'] * $this->V;
+    }
+    /**
+     * Get regression parameters (V and K)
+     *
+     * @return array [ V => number, K => number ]
+     */
+    public function getParameters(): array
+    {
+        return [
+            'V' => $this->V,
+            'K' => $this->K,
+        ];
+    }
+    /**
+     * Get regression equation (y = V * X / (K + X))
+     *
+     * @return string
+     */
+    public function getEquation(): string
+    {
+        return sprintf('y = %fx/(%f+x)', $this->V, $this->K);
+    }
+   /**
+    * Evaluate the equation using the regression parameters
+    * y = V * X / (K + X)
+    *
+    * @param number $x
+    *
+    * @return number y evaluated
+    */
+    public function evaluate($x)
+    {
+        return ($this->V * $x) / ($this->K + $x);
+    }
+}

--- a/src/Statistics/Regression/LineweaverBurk.php
+++ b/src/Statistics/Regression/LineweaverBurk.php
@@ -16,16 +16,6 @@ class LineweaverBurk extends Regression
     use LeastSquares;
 
     /**
-     * @var number V regression parameter
-     */
-    private $V;
-
-    /**
-     * @var number K regression parameter
-     */
-    private $K;
-
-    /**
      * Calculate the regression parameters by least squares on linearized data
      * y⁻¹ = K * V⁻¹ * x⁻¹ + V⁻¹
      */
@@ -43,38 +33,4 @@ class LineweaverBurk extends Regression
         $this->K = $parameters['m'] * $this->V;
     }
 
-    /**
-     * Get regression parameters (V and K)
-     *
-     * @return array [ V => number, K => number ]
-     */
-    public function getParameters(): array
-    {
-        return [
-            'V' => $this->V,
-            'K' => $this->K,
-        ];
-    }
-    /**
-     * Get regression equation (y = V * X / (K + X))
-     *
-     * @return string
-     */
-    public function getEquation(): string
-    {
-        return sprintf('y = %fx/(%f+x)', $this->V, $this->K);
-    }
-
-   /**
-    * Evaluate the equation using the regression parameters
-    * y = V * X / (K + X)
-    *
-    * @param number $x
-    *
-    * @return number y evaluated
-    */
-    public function evaluate($x)
-    {
-        return ($this->V * $x) / ($this->K + $x);
-    }
 }

--- a/src/Statistics/Regression/LineweaverBurk.php
+++ b/src/Statistics/Regression/LineweaverBurk.php
@@ -11,7 +11,7 @@ use Math\Functions\Map\Single;
  *
  * The equation is linearized and fit using Least Squares
  */
-class LineweaverBurk extends Regression
+class LineweaverBurk extends MichaelisMenten
 {
     use LeastSquares;
 

--- a/src/Statistics/Regression/MichaelisMenten.php
+++ b/src/Statistics/Regression/MichaelisMenten.php
@@ -1,5 +1,5 @@
 <?php
-
+namespace Math\Statistics\Regression;
 /**
  * The Michaelis-Menten equation is used to model enzyme kinetics.
  *       V * x

--- a/src/Statistics/Regression/MichaelisMenten.php
+++ b/src/Statistics/Regression/MichaelisMenten.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * The Michaelis-Menten equation is used to model enzyme kinetics.
+ *       V * x
+ * y = ----------
+ *       K + x
+ *
+ *
+ * https://en.wikipedia.org/wiki/Michaelis%E2%80%93Menten_kinetics
+ */
+abstract class MichaelisMenten extends Regression
+{
+    /**
+     * @var number V regression parameter
+     */
+    protected $V;
+    /**
+     * @var number K regression parameter
+     */
+    protected $K;
+
+    /**
+     * Get regression parameters (V and K)
+     *
+     * @return array [ V => number, K => number ]
+     */
+    public function getParameters(): array
+    {
+        return [
+            'V' => $this->V,
+            'K' => $this->K,
+        ];
+    }
+    /**
+     * Get regression equation (y = V * X / (K + X))
+     *
+     * @return string
+     */
+    public function getEquation(): string
+    {
+        return sprintf('y = %fx/(%f+x)', $this->V, $this->K);
+    }
+   /**
+    * Evaluate the equation using the regression parameters
+    * y = V * X / (K + X)
+    *
+    * @param number $x
+    *
+    * @return number y evaluated
+    */
+    public function evaluate($x)
+    {
+        return ($this->V * $x) / ($this->K + $x);
+    }
+}

--- a/tests/Statistics/Regression/HanesWoolfTest.php
+++ b/tests/Statistics/Regression/HanesWoolfTest.php
@@ -8,7 +8,7 @@ class HanesWoolfTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetParameters(array $points, $V, $K)
     {
-        $regression = new LineweaverBurk($points);
+        $regression = new HanesWoolf($points);
         $parameters = $regression->getParameters();
         $this->assertEquals($V, $parameters['V'], '', 0.0001);
         $this->assertEquals($K, $parameters['K'], '', 0.0001);

--- a/tests/Statistics/Regression/HanesWoolfTest.php
+++ b/tests/Statistics/Regression/HanesWoolfTest.php
@@ -1,0 +1,25 @@
+<?php
+namespace Math\Statistics\Regression;
+class HanesWoolfTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @dataProvider dataProviderForParameters
+     */
+    public function testGetParameters(array $points, $V, $K)
+    {
+        $regression = new LineweaverBurk($points);
+        $parameters = $regression->getParameters();
+        $this->assertEquals($V, $parameters['V'], '', 0.0001);
+        $this->assertEquals($K, $parameters['K'], '', 0.0001);
+    }
+    public function dataProviderForParameters()
+    {
+        return [
+            [
+                [ [.038, .05], [.194, .127], [.425, .094], [.626, .2122], [1.253, .2729], [2.5, .2665], [3.740, .3317] ],
+                0.361512337, 0.554178955,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Added another Michaelis–Menten linearization.
Separated the model (evaluate, getParameters, etc) from the linearization for both this new class and the Lineweaver-Burk. My reasoning is, when matrix inverse is complete, I can extend the MichaelisMenten class to a non-linear least squares regression as well, using the model Jacobian.