### PR TITLE
Trapezoidal Rule

### DIFF
--- a/src/NumericalAnalysis/TrapezoidalRule.php
+++ b/src/NumericalAnalysis/TrapezoidalRule.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Math\NumericalAnalysis;
+
+/**
+ * Trapezoidal Rule
+ *
+ * In numerical analysis, the trapezoidal rule is a technique for approximating
+ * the definite integral of a function.
+ *
+ * The trapezoidal rule belongs to the Newton-Cotes formulas, a group of methods
+ * for numerical integration which approximate the integral of a function when
+ * the antiderivative of that function is not known or is not explicity given.
+ * Instead, we use the Newton-Cotes formulas when we are given a set of inputs
+ * and their corresponding outputs for our function. We then use these values to
+ * interpolate a Lagrange polynomial. Finally, we integrate the Lagrange
+ * polynomial to approximate the integral of our original function.
+ *
+ * The trapezoidal rule is produced by integrating the first Lagrange polynomial.
+ *
+ * https://en.wikipedia.org/wiki/Trapezoidal_rule
+ */
+class TrapezoidalRule
+{
+    /**
+     * Use the Trapezoidal Rule to aproximate the definite integral of a
+     * function f(x). Each array in our input contains two numbers which
+     * correspond to coordinates (x, y) or equivalently, (x, f(x)), of the
+     * function f(x) whose definite integral we are approximating.
+     *
+     * The bounds of the definite integral to which we are approximating is
+     * determined by the minimum and maximum values of our x-components in our
+     * input coordinates (arrays).
+     *
+     * Example: solve([0, 10], [3, 5], [10, 7]) will approximate the definite
+     * integral of the function that produces these coordinates with a lower
+     * bound of 0, and an upper bound of 10.
+     *
+     * @param  array ... $arrays Two or more arrays, each containing precisely
+     *                           two numbers
+     *
+     * @return number            The approximation to the integral of f(x)
+     */
+    public static function solve(array ... $arrays)
+    {
+        // Validate and sort arrays
+        self::validate($arrays);
+        $sorted = self::sort($arrays);
+
+        // Initialize
+        $number_of_arrays = (count($sorted));
+        $steps            = $number_of_arrays - 1;
+        $approximation    = 0;
+
+        // Summation
+        for ($i = 0; $i < $steps; $i++) {
+            $x0             = $sorted[$i][0];
+            $x1             = $sorted[$i+1][0];
+            $y0             = $sorted[$i][1];
+            $y1             = $sorted[$i+1][1];
+            $average_y      = ($y1 + $y0)/2;
+            $delta_x        = $x1 - $x0;
+            $approximation += $delta_x*$average_y;
+        }
+
+        return $approximation;
+    }
+
+    /**
+     * Validate that there are two or more arrays, that each array has precisely
+     * two numbers, and that no two arrays share the same first number
+     * (x-component)
+     *
+     * @param  array $arrays
+     *
+     * @return bool
+     * @throws Exception if there are less than two arrays
+     * @throws Exception if any array does not contain two numbers
+     * @throws Exception if two arrays share the same first number (x-component)
+     */
+    public static function validate(array $arrays)
+    {
+        if (count($arrays) < 2) {
+            throw new \Exception('You need to have at least two sets of
+                                  coordinates (arrays)');
+        }
+
+        $x_coordinates = [];
+        foreach ($arrays as $array) {
+            if (count($array) !== 2) {
+                throw new \Exception('Each array needs to have have precisely
+                                      two numbers, an x- and y-component');
+            }
+
+            $x_component = $array[0];
+            if (in_array($x_component, $x_coordinates)) {
+                throw new \Exception('Not a function. Your input array contains
+                                      more than one coordinate with the same
+                                      x-component.');
+            }
+            array_push($x_coordinates, $x_component);
+        }
+    }
+
+    /**
+     * Sorts our coordinates (arrays) by their x-component (first number) such
+     * that consecutive coordinates have an increasing x-component.
+     *
+     * @param  array $arrays
+     *
+     * @return array
+     */
+    public static function sort(array $arrays)
+    {
+        $pairs = [];
+        foreach ($arrays as $array) {
+            $pairs[$array[0]] = [$array[0], $array[1]];
+        }
+        ksort($pairs);
+
+        $sorted = [];
+        while ($pair = current($pairs)) {
+            array_push($sorted, $pair);
+            next($pairs);
+        }
+
+        return $sorted;
+    }
+}

--- a/tests/NumericalAnalysis/TrapezoidalRuleTest.php
+++ b/tests/NumericalAnalysis/TrapezoidalRuleTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Math\NumericalAnalysis;
+
+include('src/NumericalAnalysis/TrapezoidalRule.php');
+
+class TrapezoidalRuleTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSolvePolynomial()
+    {
+        // f(x)                            = x² + 2x + 1
+        // Antiderivative F(x)             = (1/3)x³ + x² + x
+        // Indefinite integral over [0, 3] = F(3) - F(0) = 21
+
+        $expected = 21;
+
+        // h₁, h₂, ... denotes the size on interval 1, 2, ...
+        // ζ₁, ζ₂, ... denotes the max of the second derivative of f(x) on
+        //             interval 1, 2, ...
+        // f'(x)  = 2x + 2
+        // f''(x) = 2
+        // ζ      = f''(x) = 2
+        // Error  = Sum(ζ₁h₁³ + ζ₂h₂³ + ...) = 2 * Sum(h₁³ + h₂³ + ...)
+
+        // Approximate with endpoints: (0, 1) and (3, 16)
+        // Error = 2 * ((3 - 0)²) = 18
+        $tol = 18;
+        $x = TrapezoidalRule::solve([0, 1], [3, 16]);
+        $this->assertEquals($expected, $x, '', $tol);
+
+        // Approximate with endpoints and one interior point: (0, 1), (1, 4),
+        // and (3, 16)
+        // Error = 2 * ((1 - 0)² + (3 - 1)²) = 10
+        $tol = 10;
+        $x = TrapezoidalRule::solve([0, 1], [1, 4], [3, 16]);
+        $this->assertEquals($expected, $x, '', $tol);
+
+        // Approximate with endpoints and two interior points: (0, 1), (1, 4),
+        // (2, 9), and (3, 16)
+        // Error = 2 * ((1 - 0)² + (2 - 1)² + (3 - 2)²) = 6
+        $tol = 6;
+        $x = TrapezoidalRule::solve([0, 1], [1, 4], [2, 9], [3, 16]);
+        $this->assertEquals($expected, $x, '', $tol);
+    }
+
+    public function testNotCoordinatesException()
+    {
+        // An array doesn't have precisely two numbers (coordinates)
+        $this->setExpectedException('\Exception');
+        TrapezoidalRule::solve([0,0],[1,2,3]);
+    }
+
+    public function testNotEnoughArraysException()
+    {
+        // There are not enough arrays in the input
+        $this->setExpectedException('\Exception');
+        TrapezoidalRule::solve([0,0]);
+    }
+
+    public function testNotAFunctionException()
+    {
+        // Two arrays share the same first number (x-component)
+        $this->setExpectedException('\Exception');
+        TrapezoidalRule::solve([0,0], [0,5], [1,1]);
+    }
+}

--- a/tests/NumericalAnalysis/TrapezoidalRuleTest.php
+++ b/tests/NumericalAnalysis/TrapezoidalRuleTest.php
@@ -2,8 +2,6 @@
 
 namespace Math\NumericalAnalysis;
 
-include('src/NumericalAnalysis/TrapezoidalRule.php');
-
 class TrapezoidalRuleTest extends \PHPUnit_Framework_TestCase
 {
     public function testSolvePolynomial()
@@ -47,7 +45,7 @@ class TrapezoidalRuleTest extends \PHPUnit_Framework_TestCase
     {
         // An array doesn't have precisely two numbers (coordinates)
         $this->setExpectedException('\Exception');
-        TrapezoidalRule::solve([0,0],[1,2,3]);
+        TrapezoidalRule::solve([0,0], [1,2,3]);
     }
 
     public function testNotEnoughArraysException()


### PR DESCRIPTION
I have added the Trapezoidal rule for numerical integration (quadrature) and its corresponding unit test.

If everything looks good, I can do the remaining Newton-Cotes formulas.

Note: I fixed the two errors that were present in the previous pull request