### PR TITLE
Added test for getPoints() Exception, added splat for $args input in approximate()

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ $f⟮x⟯ = function ($x) {
 $start = 0;
 $end = 3;
 $n = 4;
-$∫f⟮x⟯dx = TrapezoidalRule::approximate($f⟮x⟯, [$start, $end, $n]);
+$∫f⟮x⟯dx = TrapezoidalRule::approximate($f⟮x⟯, $start, $end, $n);
 
 // Simpsons Rule (Newton-Cotes formula)
 // Approximate the definite integral of a function. Input can be either a set
@@ -371,7 +371,7 @@ $f⟮x⟯ = function ($x) {
 $start = 0;
 $end = 3;
 $n = 5;
-$∫f⟮x⟯dx = TrapezoidalRule::approximate($f⟮x⟯, [$start, $end, $n]);
+$∫f⟮x⟯dx = TrapezoidalRule::approximate($f⟮x⟯, $start, $end, $n);
 ```
 
 ### Probability - Combinatorics

--- a/src/NumericalAnalysis/NumericalIntegration/NumericalIntegration.php
+++ b/src/NumericalAnalysis/NumericalIntegration/NumericalIntegration.php
@@ -27,63 +27,6 @@ abstract class NumericalIntegration
     abstract public static function approximate($source, array $args);
 
     /**
-     * Validate that there are enough input arrays (points), that each point array
-     * has precisely two numbers, and that no two points share the same first number
-     * (x-component)
-     *
-     * @param  array  $points Array of arrays (points)
-     * @param  number $degree The miminum number of input arrays
-     *
-     * @return bool
-     * @throws Exception if there are less than two points
-     * @throws Exception if any point does not contain two numbers
-     * @throws Exception if two points share the same first number (x-component)
-     */
-    protected static function validate(array $points, $degree)
-    {
-        if (count($points) < $degree) {
-            throw new \Exception("You need to have at least $degree sets of
-                                  coordinates (arrays) for this technique");
-        }
-
-        $x_coordinates = [];
-        foreach ($points as $point) {
-            if (count($point) !== 2) {
-                throw new \Exception("Each array needs to have have precisely
-                                      two numbers, an x- and y-component");
-            }
-
-            $x_component = $point[self::X];
-            if (in_array($x_component, $x_coordinates)) {
-                throw new \Exception("Not a function. Your input array contains
-                                      more than one coordinate with the same
-                                      x-component.");
-            }
-            array_push($x_coordinates, $x_component);
-        }
-
-        return true;
-    }
-
-    /**
-     * Sorts our coordinates (arrays) by their x-component (first number) such
-     * that consecutive coordinates have an increasing x-component.
-     *
-     * @param  array $points
-     *
-     * @return array
-     */
-    protected static function sort(array $points)
-    {
-        $x = self::X;
-        usort($points, function ($a, $b) use ($x) {
-            return $a[$x] <=> $b[$x];
-        });
-
-        return $points;
-    }
-
-    /**
      * Determine where the input $source argument is a callback function, a set
      * of arrays, or neither. If $source is a callback function, run it through
      * the functionToPoints() method with the input $args, and set $points to
@@ -99,7 +42,7 @@ abstract class NumericalIntegration
      * @return array
      * @throws Exception if $source is not callable or a set of arrays
      */
-    protected static function getPoints($source, array $args = [])
+    public static function getPoints($source, array $args = [])
     {
         if (is_callable($source)) {
             // To do: add method to verify function is continuous on our interval
@@ -141,6 +84,63 @@ abstract class NumericalIntegration
             $f⟮xᵢ⟯       = call_user_func_array($function, [$xᵢ]);
             $points[$i] = [$xᵢ, $f⟮xᵢ⟯];
         }
+        return $points;
+    }
+
+    /**
+     * Validate that there are enough input arrays (points), that each point array
+     * has precisely two numbers, and that no two points share the same first number
+     * (x-component)
+     *
+     * @param  array  $points Array of arrays (points)
+     * @param  number $degree The miminum number of input arrays
+     *
+     * @return bool
+     * @throws Exception if there are less than two points
+     * @throws Exception if any point does not contain two numbers
+     * @throws Exception if two points share the same first number (x-component)
+     */
+    public static function validate(array $points, $degree = 2)
+    {
+        if (count($points) < $degree) {
+            throw new \Exception("You need to have at least $degree sets of
+                                  coordinates (arrays) for this technique");
+        }
+
+        $x_coordinates = [];
+        foreach ($points as $point) {
+            if (count($point) !== 2) {
+                throw new \Exception("Each array needs to have have precisely
+                                      two numbers, an x- and y-component");
+            }
+
+            $x_component = $point[self::X];
+            if (in_array($x_component, $x_coordinates)) {
+                throw new \Exception("Not a function. Your input array contains
+                                      more than one coordinate with the same
+                                      x-component.");
+            }
+            array_push($x_coordinates, $x_component);
+        }
+
+        return true;
+    }
+
+    /**
+     * Sorts our coordinates (arrays) by their x-component (first number) such
+     * that consecutive coordinates have an increasing x-component.
+     *
+     * @param  array $points
+     *
+     * @return array
+     */
+    protected static function sort(array $points)
+    {
+        $x = self::X;
+        usort($points, function ($a, $b) use ($x) {
+            return $a[$x] <=> $b[$x];
+        });
+
         return $points;
     }
 }

--- a/src/NumericalAnalysis/NumericalIntegration/NumericalIntegration.php
+++ b/src/NumericalAnalysis/NumericalIntegration/NumericalIntegration.php
@@ -24,7 +24,7 @@ abstract class NumericalIntegration
      */
     const Y = 1;
 
-    abstract public static function approximate($source, array $args);
+    abstract public static function approximate($source, ...$args);
 
     /**
      * Determine where the input $source argument is a callback function, a set
@@ -45,7 +45,10 @@ abstract class NumericalIntegration
     public static function getPoints($source, array $args = [])
     {
         if (is_callable($source)) {
-            // To do: add method to verify function is continuous on our interval
+            // To do: Add method to verify function is continuous on our interval
+            // To do: Add method to verify input arguments are valid. Verify
+            //        $start and $end are numbers, $end > $start, and $points is
+            //        an integer > 1
             $function = $source;
             $start    = $args[0];
             $end      = $args[1];

--- a/src/NumericalAnalysis/NumericalIntegration/SimpsonsRule.php
+++ b/src/NumericalAnalysis/NumericalIntegration/SimpsonsRule.php
@@ -60,18 +60,19 @@ class SimpsonsRule extends NumericalIntegration
      *
      *  where h = xᵢ₊₁ - xᵢ
      *
-     * @param          $source The source of our approximation. Should be either
-     *                         a callback function or a set of arrays. Each array
-     *                         (point) contains precisely two numbers, an x and y.
-     *                         Example array: [[1,2], [2,3], [3,4]].
-     *                         Example callback: function($x) {return $x**2;}
-     * @param  array   $args   The arguments of our callback function: start,
-     *                         end, and n. Example: [0, 8, 5]. If $source is a
-     *                         set of arrays, $args will default to [].
+     * @param          $source   The source of our approximation. Should be either
+     *                           a callback function or a set of arrays. Each array
+     *                           (point) contains precisely two numbers, an x and y.
+     *                           Example array: [[1,2], [2,3], [3,4]].
+     *                           Example callback: function($x) {return $x**2;}
+     * @param numbers  ... $args The arguments of our callback function: start,
+     *                           end, and n. Example: approximate($source, 0, 8, 5).
+     *                           If $source is a set of points, do not input any
+     *                           $args. Example: approximate($source).
      *
-     * @return number          The approximation to the integral of f(x)
+     * @return number            The approximation to the integral of f(x)
      */
-    public static function approximate($source, array $args = [])
+    public static function approximate($source, ... $args)
     {
         // get an array of points from our $source argument
         $points = self::getPoints($source, $args);

--- a/src/NumericalAnalysis/NumericalIntegration/TrapezoidalRule.php
+++ b/src/NumericalAnalysis/NumericalIntegration/TrapezoidalRule.php
@@ -56,18 +56,19 @@ class TrapezoidalRule extends NumericalIntegration
      *
      *  where h = xᵢ₊₁ - xᵢ
      *  note: this implementation does not compute the error term.
-     * @param          $source The source of our approximation. Should be either
-     *                         a callback function or a set of arrays. Each array
-     *                         (point) contains precisely two numbers, an x and y.
-     *                         Example array: [[1,2], [2,3], [3,4]].
-     *                         Example callback: function($x) {return $x**2;}
-     * @param  array   $args   The arguments of our callback function: start,
-     *                         end, and n. Example: [0, 8, 5]. If $source is a
-     *                         set of arrays, $args will default to [].
+     * @param          $source   The source of our approximation. Should be either
+     *                           a callback function or a set of arrays. Each array
+     *                           (point) contains precisely two numbers, an x and y.
+     *                           Example array: [[1,2], [2,3], [3,4]].
+     *                           Example callback: function($x) {return $x**2;}
+     * @param numbers  ... $args The arguments of our callback function: start,
+     *                           end, and n. Example: approximate($source, 0, 8, 5).
+     *                           If $source is a set of points, do not input any
+     *                           $args. Example: approximate($source).
      *
-     * @return number          The approximation to the integral of f(x)
+     * @return number            The approximation to the integral of f(x)
      */
-    public static function approximate($source, array $args = [])
+    public static function approximate($source, ... $args)
     {
         // get an array of points from our $source argument
         $points = self::getPoints($source, $args);

--- a/tests/NumericalAnalysis/NumericalIntegration/NumericalIntegrationTest.php
+++ b/tests/NumericalAnalysis/NumericalIntegration/NumericalIntegrationTest.php
@@ -8,6 +8,36 @@ class NumbericalIntegrationTest extends \PHPUnit_Framework_TestCase
     {
         // Instantiating NumericalIntegration (an abstract class)
         $this->setExpectedException('\Error');
-        new Math\NumericalAnalysis\NumericalIntegration\NumericalIntegration;
+        new NumericalIntegration;
+    }
+
+    public function testIncorrectInput()
+    {
+        // The input $source is neither a callback or a set of arrays
+        $this->setExpectedException('\Exception');
+        $x                 = 10;
+        $incorrectFunction = $x**2 + 2 * $x + 1;
+        NumericalIntegration::getPoints($incorrectFunction, [0,4,5]);
+    }
+
+    public function testNotCoordinatesException()
+    {
+        // An array doesn't have precisely two numbers (coordinates)
+        $this->setExpectedException('\Exception');
+        NumericalIntegration::validate([[0,0], [1,2,3], [2,2]]);
+    }
+
+    public function testNotEnoughArraysException()
+    {
+        // There are not enough arrays in the input
+        $this->setExpectedException('\Exception');
+        NumericalIntegration::validate([[0,0]]);
+    }
+
+    public function testNotAFunctionException()
+    {
+        // Two arrays share the same first number (x-component)
+        $this->setExpectedException('\Exception');
+        NumericalIntegration::validate([[0,0], [0,5], [1,1]]);
     }
 }

--- a/tests/NumericalAnalysis/NumericalIntegration/SimpsonsRuleTest.php
+++ b/tests/NumericalAnalysis/NumericalIntegration/SimpsonsRuleTest.php
@@ -38,8 +38,10 @@ class SimpsonsRuleTest extends \PHPUnit_Framework_TestCase
         $func = function ($x) {
             return $x**2 + 2 * $x + 1;
         };
-        $args = [0, 3, 3];
-        $x = SimpsonsRule::approximate($func, $args);
+        $start = 0;
+        $end   = 3;
+        $n     = 3;
+        $x     = SimpsonsRule::approximate($func, $start, $end, $n);
         $this->assertEquals($expected, $x, '', $tol);
     }
 

--- a/tests/NumericalAnalysis/NumericalIntegration/SimpsonsRuleTest.php
+++ b/tests/NumericalAnalysis/NumericalIntegration/SimpsonsRuleTest.php
@@ -43,27 +43,6 @@ class SimpsonsRuleTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $x, '', $tol);
     }
 
-    public function testNotCoordinatesException()
-    {
-        // An array doesn't have precisely two numbers (coordinates)
-        $this->setExpectedException('\Exception');
-        SimpsonsRule::approximate([[0,0], [1,2,3], [2,2]]);
-    }
-
-    public function testNotEnoughArraysException()
-    {
-        // There are not enough arrays in the input
-        $this->setExpectedException('\Exception');
-        SimpsonsRule::approximate([[0,0]]);
-    }
-
-    public function testNotAFunctionException()
-    {
-        // Two arrays share the same first number (x-component)
-        $this->setExpectedException('\Exception');
-        SimpsonsRule::approximate([[0,0], [0,5], [1,1]]);
-    }
-
     public function testSubintervalsNotEvenException()
     {
         // There are not even even number of subintervals, or

--- a/tests/NumericalAnalysis/NumericalIntegration/TrapezoidalRuleTest.php
+++ b/tests/NumericalAnalysis/NumericalIntegration/TrapezoidalRuleTest.php
@@ -50,9 +50,11 @@ class TrapezoidalRuleTest extends \PHPUnit_Framework_TestCase
         $func = function ($x) {
             return $x**2 + 2 * $x + 1;
         };
-        $args = [0, 3, 4];
-        $tol = 6;
-        $x = TrapezoidalRule::approximate($func, $args);
+        $start = 0;
+        $end   = 3;
+        $n     = 4;
+        $tol   = 6;
+        $x     = TrapezoidalRule::approximate($func, $start, $end, $n);
         $this->assertEquals($expected, $x, '', $tol);
     }
 }

--- a/tests/NumericalAnalysis/NumericalIntegration/TrapezoidalRuleTest.php
+++ b/tests/NumericalAnalysis/NumericalIntegration/TrapezoidalRuleTest.php
@@ -55,25 +55,4 @@ class TrapezoidalRuleTest extends \PHPUnit_Framework_TestCase
         $x = TrapezoidalRule::approximate($func, $args);
         $this->assertEquals($expected, $x, '', $tol);
     }
-
-    public function testNotCoordinatesException()
-    {
-        // An array doesn't have precisely two numbers (coordinates)
-        $this->setExpectedException('\Exception');
-        TrapezoidalRule::approximate([[0,0], [1,2,3]]);
-    }
-
-    public function testNotEnoughArraysException()
-    {
-        // There are not enough arrays in the input
-        $this->setExpectedException('\Exception');
-        TrapezoidalRule::approximate([[0,0]]);
-    }
-
-    public function testNotAFunctionException()
-    {
-        // Two arrays share the same first number (x-component)
-        $this->setExpectedException('\Exception');
-        TrapezoidalRule::approximate([[0,0], [0,5], [1,1]]);
-    }
 }


### PR DESCRIPTION
### Updates

- Updated comments to reflect splat in $args input (instead of array)

- Updated tests to reflect splat in $args input (instead of array)

- Updated readme to reflect splat in $args input (instead of array)

- Moved common tests (the three Exceptions in validate()) outside of individual class tests and into their parent class test (NumericalIntegration) by making the corresponding methods public and accessing them directly in the test. Example:

 ```
 NumericalIntegration::validate([1,0],[2,1],[1,4]);
 ```