### PR TITLE
Fix Vector pNorm for odd powers

### DIFF
--- a/src/LinearAlgebra/Vector.php
+++ b/src/LinearAlgebra/Vector.php
@@ -481,7 +481,7 @@ class Vector implements \Countable, \ArrayAccess, \JsonSerializable
      */
     public function pNorm($p)
     {
-        return array_sum(Map\Single::pow($this->A, $p))**(1/$p);
+        return array_sum(Map\Single::pow(Map\Single::abs($this->A), $p))**(1/$p);
     }
 
     /**

--- a/tests/LinearAlgebra/VectorNormsTest.php
+++ b/tests/LinearAlgebra/VectorNormsTest.php
@@ -61,6 +61,8 @@ class VectorNormsTest extends \PHPUnit_Framework_TestCase
         return [
             [ [1, 2, 3], 2, 3.74165738677 ],
             [ [1, 2, 3], 3, 3.30192724889 ],
+            [ [-1, 2, -3], 1, 6 ],
+            [ [-1, 2, -3], 3, 3.30192724889 ],
         ];
     }
 


### PR DESCRIPTION
The pNorm should take the absolute value of each component of the vector, so that negative components also have a positive contribution to the norm when p is odd.