### PR TITLE
Complex roots of Cubic Polynomials

### DIFF
--- a/src/Algebra.php
+++ b/src/Algebra.php
@@ -298,7 +298,7 @@ class Algebra
      * @return array of roots (three real roots, or one real root and two NANs because complex numbers not yet supported)
      *                        (If $a₃ = 0, then only two roots of quadratic equation)
      */
-    public static function cubic($a₃, $a₂, $a₁, $a₀): array
+    public static function cubic($a₃, $a₂, $a₁, $a₀, $return_complex = false): array
     {
         if ($a₃ === 0) {
             return self::quadratic($a₂, $a₁, $a₀);
@@ -345,6 +345,14 @@ class Algebra
         // D > 0: One root is real, and two are are complex conjugates
         $z₁ = $S + $T - $a₂ / 3;
 
-        return [$z₁, \NAN, \NAN];
+        if (!$return_complex) {
+            return [$z₁, \NAN, \NAN];
+        } else {
+            $quad_a = 1;
+            $quad_b = $a₂ + $z₁;
+            $quad_c = $a₁ + $quad_b * $z₁;
+            $complex_roots = self::quadratic($quad_a, $quad_b, $quad_c, true);
+            return array_merge([$z₁], $complex_roots);
+        }
     }
 }

--- a/src/Number/Complex.php
+++ b/src/Number/Complex.php
@@ -26,7 +26,12 @@ class Complex
      * @var number
      */
     protected $i;
-
+    
+    /**
+     * Floating-point range near zero to consider insignificant.
+     */
+    const EPSILON = 1e-6;
+    
     /**
      * Constructor
      *
@@ -362,6 +367,6 @@ class Complex
      */
     public function equals(Complex $c): bool
     {
-        return $this->r == $c->r && $this->i == $c->i;
+        return abs($this->r - $c->r) < self::EPSILON && abs($this->i - $c->i) < self::EPSILON;
     }
 }

--- a/tests/Algebra/AlgebraTest.php
+++ b/tests/Algebra/AlgebraTest.php
@@ -351,6 +351,38 @@ class AlgebraTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @testCase     cubic returns the expected roots when D > 0: one root is real, 2 are complex conjugates.
+     * @dataProvider dataProviderForCubicOneRealRootWithComplex
+     * @param        int $a
+     * @param        int $b
+     * @param        int $c
+     * @param        int $d
+     * @param        array $cubic expected roots
+     */
+    public function testCubicOneRealRootWithComplex($a, $b, $c, $d, $roots)
+    {
+        $real_root = $roots[0];
+        $complex0 = new Number\Complex($roots[1]['r'], $roots[1]['i']);
+        $complex1 = new Number\Complex($roots[2]['r'], $roots[2]['i']);
+        list($z₁, $z₂, $z₃) = Algebra::cubic($a, $b, $c, $d, true);
+        $this->assertEquals($real_root, $z₁, '', 0.00000001);
+        $this->assertInstanceOf(Number\Complex::class, $z₂);
+        $this->assertInstanceOf(Number\Complex::class, $z₃);
+        $this->assertTrue($z₂->equals($complex0), "Expecting $complex0 but saw $z₂");
+        $this->assertTrue($z₃->equals($complex1), "Expecting $complex1 but saw $z₃");
+    }
+
+    public function dataProviderForCubicOneRealRootWithComplex(): array
+    {
+        return [
+            // D > 0: one root is real, 2 are complex conjugates.
+            [1, 0, 1, 0, [0, ['r'=>0, 'i'=>-1], ['r'=>0, 'i'=>1]]],
+            [1, -1, 1, -1, [1, ['r'=>0, 'i'=>-1], ['r'=>0, 'i'=>1]]],
+            
+        ];
+    }
+
+    /**
      * @testCase     cubic with a₃ coefficient of z³ of 0 is the same as quadratic.
      * @dataProvider dataProviderForQuadratic
      * @param        number $b


### PR DESCRIPTION
This patch extends ComplexNumber support to Cubic Polynomials. The ComplexNumber::equals() method was refactored to use an epsilon range to help floating point comparisons. 