### PR TITLE
Failing unit test

### DIFF
--- a/tests/LinearAlgebra/MatrixDecompositionsTest.php
+++ b/tests/LinearAlgebra/MatrixDecompositionsTest.php
@@ -313,6 +313,18 @@ class MatrixDecompositionsTest extends \PHPUnit_Framework_TestCase
         return [
             [
                 [
+                    [3, -4, 2],
+                    [-2, 6, 2],
+                    [4, 2, 10],
+                ],
+                [
+                    [1, 0, 2],
+                    [0, 1, 1],
+                    [0, 0, 0],
+                ],
+            ],
+            [
+                [
                     [1, 2, 3],
                     [2, 3, 4],
                     [3, 4, 5],


### PR DESCRIPTION
There is a bug somewhere in the matrix code. Some code I am working on failing because this Matrix::rref() is incorrect. It is currently returning an identity matrix instead of:

    [1 0 2]
    [0 1 1]
    [0 0 0]