### PR TITLE
add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+composer.lock


### PR DESCRIPTION
It's pretty standard to exclude the vendor directory. I used `git add -A` and it added all vendor files to the staging area, so I had to git reset, because I assumed based on my previous experience with php libraries, that the vendor dir is ignored.

I also added `composer.lock` to the ignore file, because it was not present and looks like you don't want to keep it in the repo.