### PR TITLE
Number theory additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,8 +776,36 @@ $n = 225;
 // Prime factorization
 $factors = Integer::primeFactorization($n);
 
-// Perfect Number
-$bool = Integer::isPerfectNumber($n);
+// Divisor function
+$int  = Integer::numberOfDivisors($n);
+$int  = Integer::sumOfDivisors($n);
+
+// Aliquot sums
+$int  = Integer::aliquotSum($n);        // sum-of-divisors - n
+$bool = Integer::isPerfectNumber($n);   // n = aliquot sum
+$bool = Integer::isDeficientNumber($n); // n > aliquot sum
+$bool = Integer::isAbundantNumber($n);  // n < aliquot sum
+
+// Totients
+$int  = Integer::totient($n);        // Jordan's totient k=1 (Euler's totient)
+$int  = Integer::totient($n, 2);     // Jordan's totient k=2
+$int  = Integer::cototient($n);      // Cototient
+$int  = Integer::reducedTotient($n); // Carmichael's function
+
+// Möbius function
+$int  = Integer::mobius($n);
+
+// Radical/squarefree kernel
+$int  = Integer::radical($n);
+
+// Squarefree integer
+$bool = Integer::isSquarefreeInteger($n);
+
+// Refactorable number
+$bool = Integer::isRefactorableNumber($n);
+
+// Sphenic number
+$bool = Integer::isSphenicNumber($n);
 
 // Perfect powers
 $bool        = Integer::isPerfectPower($n);

--- a/README.md
+++ b/README.md
@@ -798,8 +798,8 @@ $int  = Integer::mobius($n);
 // Radical/squarefree kernel
 $int  = Integer::radical($n);
 
-// Squarefree integer
-$bool = Integer::isSquarefreeInteger($n);
+// Squarefree
+$bool = Integer::isSquarefree($n);
 
 // Refactorable number
 $bool = Integer::isRefactorableNumber($n);

--- a/src/NumberTheory/Integer.php
+++ b/src/NumberTheory/Integer.php
@@ -110,12 +110,12 @@ class Integer
      *
      * @return array of prime factors
      *
-     * @throws Exception\OutOfBoundsException if n is < 2.
+     * @throws Exception\OutOfBoundsException if n is < 1.
      */
     public static function primeFactorization(int $n): array
     {
-        if ($n < 2) {
-            throw new Exception\OutOfBoundsException("n must be ≥ 2. ($n provided)");
+        if ($n < 1) {
+            throw new Exception\OutOfBoundsException("n must be ≥ 1. ($n provided)");
         }
 
         $remainder = $n;
@@ -148,6 +148,60 @@ class Integer
     public static function coprime(int $a, int $b): bool
     {
         return (Algebra::gcd($a, $b) === 1);
+    }
+
+    /**
+     * Number-of-divisors function
+     * 
+     * Notations:
+     * d(n)  v(n)  τ(n)  tau(n)  sigma_0(n)  σ₀(n)
+     * 
+     * @see    https://en.wikipedia.org/wiki/Divisor_function
+     * @see    https://oeis.org/A000005
+     *
+     * @param  int $n
+     * 
+     * @return int number of divisors
+     * 
+     * @throws Exception\OutOfBoundsException if n is < 1.
+     */
+    public static function numberOfDivisors(int $n): int
+    {
+        $factorization = self::primeFactorization($n);
+        $product = 1;
+        foreach (array_count_values($factorization) as $factor => $exponent) {
+            $product *= $exponent + 1;
+        }
+        return $product;
+    }
+
+    /**
+     * Sum-of-divisors function
+     *
+     * Notations:
+     * σ(n)  σ₁(n)  sigma(n)  sigma_1(n)
+     * 
+     * @see    https://en.wikipedia.org/wiki/Divisor_function
+     * @see    https://oeis.org/A000203
+     *
+     * @param  int $n
+     *
+     * @return int sum of divisors
+     *
+     * @throws Exception\OutOfBoundsException if n is < 1.
+     */
+    public static function sumOfDivisors(int $n): int
+    {
+        $factorization = self::primeFactorization($n);
+        $product = 1;
+        foreach (array_count_values($factorization) as $factor => $exponent) {
+            $sum = 1 + $factor;
+            for ($i = 2; $i <= $exponent; $i++) {
+                $sum += pow($factor, $i);
+            }
+            $product *= $sum;
+        }
+        return $product;
     }
 
     /**

--- a/src/NumberTheory/Integer.php
+++ b/src/NumberTheory/Integer.php
@@ -11,7 +11,8 @@ class Integer
      * Detect if an integer is a perfect number.
      * A perfect number is a positive integer that is equal to the sum of its proper positive divisors,
      * that is, the sum of its positive divisors excluding the number itself
-     * @see https://en.wikipedia.org/wiki/Perfect_number
+     * 
+     * @see    https://en.wikipedia.org/wiki/Perfect_number
      *
      * @param  int $n
      *
@@ -23,16 +24,69 @@ class Integer
             return false;
         }
 
-        $∑  = 1;
-        $√n = sqrt($n);
+        return $n === self::aliquotSum($n);
+    }
 
-        for ($i = 2; $i <= $√n; $i++) {
-            if ($n % $i === 0) {
-                $∑ += $i + ($n / $i);
-            }
+    /**
+     * Detect if an integer is a deficient (defective) number.
+     * A deficient number is a positive integer that is greater than the sum of its proper divisors,
+     * that is, the sum of its positive divisors excluding the number itself
+     * 
+     * @see    https://en.wikipedia.org/wiki/Deficient_number
+     *
+     * @param  int  $n
+     *
+     * @return bool true if n is deficient; false otherwise
+     */
+    public static function isDeficientNumber(int $n): bool
+    {
+        if ($n < 1) {
+            return false;
         }
+       return $n > self::aliquotSum($n);
+    }
 
-        return $∑ === $n;
+    /**
+     * Detect if an integer is an abundant (excessive) number.
+     * An abundant number is a positive integer that is less than the sum of its proper divisors,
+     * that is, the sum of its positive divisors excluding the number itself
+     * 
+     * @see    https://en.wikipedia.org/wiki/Abundant_number
+     *
+     * @param  int  $n
+     *
+     * @return bool true if n is abundant; false otherwise
+     */
+    public static function isAbundantNumber(int $n): bool
+    {
+        if ($n < 1) {
+            return false;
+        }
+        return $n < self::aliquotSum($n);
+    }
+
+    /**
+     * Aliquot sum
+     * The aliquot sum of a positive integer is the sum of all proper divisors of n,
+     * that is, the sum of its positive divisors excluding the number itself
+     * 
+     * Notation:
+     * s(n)
+     *
+     * Formula:
+     * σ(n) − n
+     *
+     * @see    https://en.wikipedia.org/wiki/Aliquot_sum
+     *
+     * @param  int $n
+     *
+     * @return int aliquot sum of n
+     *
+     * @throws Exception\OutOfBoundsException if n is < 1.
+     */
+    public static function aliquotSum(int $n): int
+    {
+        return self::sumOfDivisors($n) - $n;
     }
 
     /**

--- a/src/NumberTheory/Integer.php
+++ b/src/NumberTheory/Integer.php
@@ -224,6 +224,43 @@ class Integer
     }
 
     /**
+     * Refactorable (or tau) number
+     * A refactorable number is divisible by the count of its divisors σ₀(n)
+     *
+     * @see    https://en.wikipedia.org/wiki/Refactorable_number
+     * @see    https://oeis.org/A033950
+     *
+     * @param  int $n
+     *
+     * @return bool true if n is divisible by σ₀(n); false otherwise
+     */
+    public static function isRefactorableNumber(int $n): bool
+    {
+        if ($n < 1) {
+            return false;
+        }
+
+        return $n % self::numberOfDivisors($n) === 0;
+    }
+
+    /**
+     * Spheric number
+     * A spheric number is a positive integer that is the product of three distinct prime numbers.
+     *
+     * @see    https://en.wikipedia.org/wiki/Spheric_number
+     * @see    https://oeis.org/A007304
+     *
+     * @param  int $n
+     *
+     * @return bool true if n is a spheric number; false otherwise
+     */
+    public static function isSphericNumber(int $n): bool
+    {
+        $factors = self::primeFactorization($n);
+        return count($factors) === 3 && count(array_unique($factors)) === 3;
+    }
+
+    /**
      * Detect if an integer is a perfect power.
      * A perfect power is a positive integer that can be expressed as an integer power of another positive integer.
      * If n is a perfect power, then exists m > 1 and k > 1 such that mᵏ = n.
@@ -355,9 +392,9 @@ class Integer
      */
     public static function numberOfDivisors(int $n): int
     {
-        $factorization = self::primeFactorization($n);
+        $factors = self::primeFactorization($n);
         $product = 1;
-        foreach (array_count_values($factorization) as $factor => $exponent) {
+        foreach (array_count_values($factors) as $factor => $exponent) {
             $product *= $exponent + 1;
         }
         return $product;
@@ -380,9 +417,9 @@ class Integer
      */
     public static function sumOfDivisors(int $n): int
     {
-        $factorization = self::primeFactorization($n);
+        $factors = self::primeFactorization($n);
         $product = 1;
-        foreach (array_count_values($factorization) as $factor => $exponent) {
+        foreach (array_count_values($factors) as $factor => $exponent) {
             $sum = 1 + $factor;
             for ($i = 2; $i <= $exponent; $i++) {
                 $sum += pow($factor, $i);

--- a/src/NumberTheory/Integer.php
+++ b/src/NumberTheory/Integer.php
@@ -117,15 +117,21 @@ class Integer
      *    (when k=1 - Euler's totient)
      *    ϕ(n)  φ(n)  phi(n)
      *
-     * @see    https://en.wikipedia.org/wiki/Euler%27s_totient_function
-     * @see    https://en.wikipedia.org/wiki/Jordan%27s_totient_function
+     * @see    https://en.wikipedia.org/wiki/Euler's_totient_function
+     * @see    https://en.wikipedia.org/wiki/Jordan's_totient_function
      *
      * @param  int $n
+     * @param  int $k elements to include in a (k+1)-tuple with n
      *
      * @return int number of k-tuples of positive integers ≤ n that form a coprime (k+1)-tuple with n
+     *
+     * @throws Exception\OutOfBoundsException if n is < 1 or k < 1
      */
     public static function totient(int $n, int $k = 1): int
     {
+        if ($k < 1) {
+            throw new Exception\OutOfBoundsException("k must be ≥ 1. ($k provided)");
+        }
         $J = $n ** $k;
         $primes = array_unique(self::primeFactorization($n));
         foreach ($primes as $prime) {
@@ -146,6 +152,8 @@ class Integer
      * @param  int $n
      *
      * @return int number of positive integers ≤ that have at least one prime factor in common with n
+     *
+     * @throws Exception\OutOfBoundsException if n is < 1.
      */
     public static function cototient(int $n): int
     {
@@ -159,8 +167,13 @@ class Integer
      * Notation:
      *    λ(n)
      *
+     * @see    https://en.wikipedia.org/wiki/Carmichael_function
+     *
      * @param  int $n
+     *
      * @return int the exponent of the multiplicative group of integers modulo n
+     *
+     * @throws Exception\OutOfBoundsException if n is < 1.
      */
     public static function reducedTotient(int $n): int
     {
@@ -205,7 +218,7 @@ class Integer
     }
 
     /**
-     * Squarefree integer
+     * Squarefree
      * A squarefree integer is an integer which is divisble by no square number other than 1.
      * It is equal to its radical (squarefree kernel).
      *
@@ -215,7 +228,7 @@ class Integer
      * @param  int $n
      * @return bool true if n is a squarefree integer; false otherwise
      */
-    public static function isSquarefreeInteger(int $n): bool
+    public static function isSquarefree(int $n): bool
     {
         if ($n < 1) {
             return false;
@@ -253,6 +266,8 @@ class Integer
      * @param  int $n
      *
      * @return bool true if n is a sphenic number; false otherwise
+     *
+     * @throws Exception\OutOfBoundsException if n is < 1.
      */
     public static function isSphenicNumber(int $n): bool
     {

--- a/src/NumberTheory/Integer.php
+++ b/src/NumberTheory/Integer.php
@@ -90,6 +90,43 @@ class Integer
     }
 
     /**
+     * Radical (or squarefree kernel)
+     * The radical of a positive integer is the product of its distinct prime factors.
+     * 
+     * @see    https://en.wikipedia.org/wiki/Radical_of_an_integer
+     * @see    https://oeis.org/A007947
+     *
+     * @param  int $n
+     *
+     * @return int the radical of n
+     *
+     * @throws Exception\OutOfBoundsException if n is < 1.
+     */
+    public static function radical(int $n): int
+    {
+        return array_product(array_unique(self::primeFactorization($n)));
+    }
+
+    /**
+     * Squarefree integer
+     * A squarefree integer is an integer which is divisble by no square number other than 1.
+     * It is equal to its radical (squarefree kernel).
+     *
+     * @see    https://en.wikipedia.org/wiki/Square-free_integer
+     * @see    https://oeis.org/A005117
+     *
+     * @param  int $n
+     * @return bool true if n is a squarefree integer; false otherwise
+     */ 
+    public static function isSquarefreeInteger(int $n): bool
+    {
+        if ($n < 1) {
+            return false;
+        }
+        return $n === self::radical($n);
+    }
+
+    /**
      * Detect if an integer is a perfect power.
      * A perfect power is a positive integer that can be expressed as an integer power of another positive integer.
      * If n is a perfect power, then exists m > 1 and k > 1 such that mᵏ = n.

--- a/src/NumberTheory/Integer.php
+++ b/src/NumberTheory/Integer.php
@@ -108,6 +108,74 @@ class Integer
     }
 
     /**
+     * Totient function (Euler's totient and Jordan's totient)
+     * The number of k-tuples of positive integers that are all ≤ n that form a coprime (k+1)-tuple together with n.
+     *
+     * Notation:
+     *    Jₖ(n)
+     *
+     *    (when k=1 - Euler's totient)
+     *    ϕ(n)  φ(n)  phi(n)
+     *
+     * @see    https://en.wikipedia.org/wiki/Euler%27s_totient_function
+     * @see    https://en.wikipedia.org/wiki/Jordan%27s_totient_function
+     *
+     * @param  int $n
+     *
+     * @return int number of k-tuples of positive integers ≤ n that form a coprime (k+1)-tuple with n
+     */
+    public static function totient(int $n, int $k = 1): int
+    {
+        $J = $n ** $k;
+        $primes = array_unique(self::primeFactorization($n));
+        foreach ($primes as $prime) {
+            $J *= 1 - 1 / $prime ** $k;
+        }
+        return $J;
+    }
+
+    /**
+     * Cototient
+     * The number of positive integers ≤ n that have at least one prime factor in common with n.
+     *
+     * Algorithm:
+     *    n - φ(n)
+     *
+     * @see    https://en.wikipedia.org/wiki/Euler's_totient_function
+     * 
+     * @param  int $n
+     *
+     * @return int number of positive integers ≤ that have at least one prime factor in common with n
+     */
+    public static function cototient(int $n): int
+    {
+        return $n - self::totient($n);
+    }
+
+    /**
+     * Reduced totient function (Carmichael function, least universal exponent function)
+     * Return the exponent of the multiplicative group of integers modulo n.
+     *
+     * Notation:
+     *    λ(n)
+     *
+     * @param  int $n
+     * @return int the exponent of the multiplicative group of integers modulo n
+     */
+    public static function reducedTotient(int $n): int
+    {
+        $primes = array_count_values(self::primeFactorization($n));
+        $λ = 1;
+        if (isset($primes[2]) && $primes[2] > 2) {
+            --$primes[2];
+        }
+        foreach ($primes as $prime => $exponent) {
+            $λ = Algebra::lcm($λ, $prime ** ($exponent - 1) * ($prime - 1));
+        }
+        return $λ;
+    }
+
+    /**
      * Squarefree integer
      * A squarefree integer is an integer which is divisble by no square number other than 1.
      * It is equal to its radical (squarefree kernel).

--- a/src/NumberTheory/Integer.php
+++ b/src/NumberTheory/Integer.php
@@ -11,7 +11,7 @@ class Integer
      * Detect if an integer is a perfect number.
      * A perfect number is a positive integer that is equal to the sum of its proper positive divisors,
      * that is, the sum of its positive divisors excluding the number itself
-     * 
+     *
      * @see    https://en.wikipedia.org/wiki/Perfect_number
      *
      * @param  int $n
@@ -31,7 +31,7 @@ class Integer
      * Detect if an integer is a deficient (defective) number.
      * A deficient number is a positive integer that is greater than the sum of its proper divisors,
      * that is, the sum of its positive divisors excluding the number itself
-     * 
+     *
      * @see    https://en.wikipedia.org/wiki/Deficient_number
      *
      * @param  int  $n
@@ -43,14 +43,14 @@ class Integer
         if ($n < 1) {
             return false;
         }
-       return $n > self::aliquotSum($n);
+        return $n > self::aliquotSum($n);
     }
 
     /**
      * Detect if an integer is an abundant (excessive) number.
      * An abundant number is a positive integer that is less than the sum of its proper divisors,
      * that is, the sum of its positive divisors excluding the number itself
-     * 
+     *
      * @see    https://en.wikipedia.org/wiki/Abundant_number
      *
      * @param  int  $n
@@ -69,7 +69,7 @@ class Integer
      * Aliquot sum
      * The aliquot sum of a positive integer is the sum of all proper divisors of n,
      * that is, the sum of its positive divisors excluding the number itself
-     * 
+     *
      * Notation:
      * s(n)
      *
@@ -92,7 +92,7 @@ class Integer
     /**
      * Radical (or squarefree kernel)
      * The radical of a positive integer is the product of its distinct prime factors.
-     * 
+     *
      * @see    https://en.wikipedia.org/wiki/Radical_of_an_integer
      * @see    https://oeis.org/A007947
      *
@@ -142,7 +142,7 @@ class Integer
      *    n - φ(n)
      *
      * @see    https://en.wikipedia.org/wiki/Euler's_totient_function
-     * 
+     *
      * @param  int $n
      *
      * @return int number of positive integers ≤ that have at least one prime factor in common with n
@@ -176,6 +176,35 @@ class Integer
     }
 
     /**
+     * Möbius function
+     * The sum of the primitive nᵗʰ roots of unity.
+     *
+     * Notation
+     *    μ(n)  mu(n)
+     *
+     * Algorithm:
+     *    - if n is not squarefree, return 0
+     *    - return (-1)ᵏ, where k is the number of primes in n
+     *
+     * @see    https://en.wikipedia.org/wiki/M%C3%B6bius_function
+     * @see    https://oeis.org/A008683
+     *
+     * @param  int $n
+     *
+     * @return int 0 if n is not squarefree; 1 if n has an even number of prime factors; -1 if n has an odd number of prime factors
+     *
+     * @throws Exception\OutOfBoundsException if n is < 1.
+     */
+    public static function mobius(int $n): int
+    {
+        $factors = self::primeFactorization($n);
+        if ($factors !== array_unique($factors)) {
+            return 0;
+        }
+        return (-1) ** count($factors);
+    }
+
+    /**
      * Squarefree integer
      * A squarefree integer is an integer which is divisble by no square number other than 1.
      * It is equal to its radical (squarefree kernel).
@@ -185,7 +214,7 @@ class Integer
      *
      * @param  int $n
      * @return bool true if n is a squarefree integer; false otherwise
-     */ 
+     */
     public static function isSquarefreeInteger(int $n): bool
     {
         if ($n < 1) {
@@ -311,17 +340,17 @@ class Integer
 
     /**
      * Number-of-divisors function
-     * 
+     *
      * Notations:
      * d(n)  v(n)  τ(n)  tau(n)  sigma_0(n)  σ₀(n)
-     * 
+     *
      * @see    https://en.wikipedia.org/wiki/Divisor_function
      * @see    https://oeis.org/A000005
      *
      * @param  int $n
-     * 
+     *
      * @return int number of divisors
-     * 
+     *
      * @throws Exception\OutOfBoundsException if n is < 1.
      */
     public static function numberOfDivisors(int $n): int
@@ -339,7 +368,7 @@ class Integer
      *
      * Notations:
      * σ(n)  σ₁(n)  sigma(n)  sigma_1(n)
-     * 
+     *
      * @see    https://en.wikipedia.org/wiki/Divisor_function
      * @see    https://oeis.org/A000203
      *

--- a/src/NumberTheory/Integer.php
+++ b/src/NumberTheory/Integer.php
@@ -244,17 +244,17 @@ class Integer
     }
 
     /**
-     * Spheric number
-     * A spheric number is a positive integer that is the product of three distinct prime numbers.
+     * Sphenic number
+     * A sphenic number is a positive integer that is the product of three distinct prime numbers.
      *
-     * @see    https://en.wikipedia.org/wiki/Spheric_number
+     * @see    https://en.wikipedia.org/wiki/Sphenic_number
      * @see    https://oeis.org/A007304
      *
      * @param  int $n
      *
-     * @return bool true if n is a spheric number; false otherwise
+     * @return bool true if n is a sphenic number; false otherwise
      */
-    public static function isSphericNumber(int $n): bool
+    public static function isSphenicNumber(int $n): bool
     {
         $factors = self::primeFactorization($n);
         return count($factors) === 3 && count(array_unique($factors)) === 3;

--- a/tests/NumberTheory/IntegerTest.php
+++ b/tests/NumberTheory/IntegerTest.php
@@ -289,23 +289,23 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testCase     testIsSphericNumber
-     * @dataProvider dataProviderForSphericNumbers
+     * @testCase     testIsSphenicNumber
+     * @dataProvider dataProviderForSphenicNumbers
      * @param        int $n
      * @throws       \Exception
      */
-    public function testIsSphericNumber(int $n)
+    public function testIsSphenicNumber(int $n)
     {
-        $isSphericNumber = Integer::isSphericNumber($n);
-        $this->assertTrue($isSphericNumber);
+        $isSphenicNumber = Integer::isSphenicNumber($n);
+        $this->assertTrue($isSphenicNumber);
     }
 
     /**
-     * A007304 Spheric numbers: products of 3 distinct primes
+     * A007304 Sphenic numbers: products of 3 distinct primes
      * @see    https://oeis.org/A007304
      * @return array
      */
-    public function dataProviderForSphericNumbers(): array
+    public function dataProviderForSphenicNumbers(): array
     {
         return [
             [30],
@@ -331,24 +331,24 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testCase     testIsNotSphericNumber
-     * @dataProvider dataProviderForNonSphericNumbers
+     * @testCase     testIsNotSphenicNumber
+     * @dataProvider dataProviderForNonSphenicNumbers
      * @param        int $n
      * @throws       \Exception
      */
-    public function testIsNotSphericNumber(int $n)
+    public function testIsNotSphenicNumber(int $n)
     {
         // When
-        $isSphericNumber = Integer::isSphericNumber($n);
+        $isSphenicNumber = Integer::isSphenicNumber($n);
         
         // Then
-        $this->assertFalse($isSphericNumber);
+        $this->assertFalse($isSphenicNumber);
     }
 
     /**
      * @return array
      */
-    public function dataProviderForNonSphericNumbers(): array
+    public function dataProviderForNonSphenicNumbers(): array
     {
         return [
             [2],

--- a/tests/NumberTheory/IntegerTest.php
+++ b/tests/NumberTheory/IntegerTest.php
@@ -297,6 +297,133 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @testCase     testRadical
+     * @dataProvider dataProviderForRadical
+     * @param        int $n
+     * @throws       \Exception
+     */
+    public function testRadical(int $n, int $expected)
+    {
+        $radical= Integer::radical($n);
+        $this->assertEquals($expected, $radical);
+    }
+
+    /**
+     * A007947 the squarefree kernel of n
+     * @see    https://oeis.org/A007947
+     * @return array
+     */
+    public function dataProviderForRadical(): array
+    {
+        return [
+            [1, 1],
+            [2, 2],
+            [3, 3],
+            [4, 2],
+            [5, 5],
+            [6, 6],
+            [7, 7],
+            [8, 2],
+            [9, 3],
+            [10, 10],
+            [11, 11],
+            [12, 6],
+            [13, 13],
+            [14, 14],
+            [15, 15],
+            [16, 2],
+            [17, 17],
+            [18, 6],
+            [19, 19],
+        ];
+    }
+
+    /**
+     * @testCase     radical throws an OutOfBoundsException if n is < 1.
+     * @dataProvider dataProviderForPrimeFactorizationOutOfBoundsException
+     * @param        int $n
+     * @throws       \Exception
+     */
+    public function testRadicalOutOfBoundsException(int $n)
+    {
+        // When
+        $this->expectException(Exception\OutOfBoundsException::class);
+
+        // Then
+        Integer::radical($n);
+    }
+
+    /**
+     * @testCase     testIsSquarefreeInteger
+     * @dataProvider dataProviderForSquarefreeIntegers
+     * @param        int $n
+     * @throws       \Exception
+     */
+    public function testIsSquarefreeInteger(int $n)
+    {
+        $isSquarefreeInteger = Integer::isSquarefreeInteger($n);
+        $this->assertTrue($isSquarefreeInteger);
+    }
+
+    /**
+     * A005117 squarefree numbers: numbers that are not divisible by a square greater than 1
+     * @see    https://oeis.org/A005117
+     * @return array
+     */
+    public function dataProviderForSquarefreeIntegers(): array
+    {
+        return [
+            [1],
+            [2],
+            [3],
+            [5],
+            [6],
+            [7],
+            [10],
+            [11],
+            [13],
+            [14],
+            [15],
+            [17],
+            [19],
+            [21],
+            [22],
+            [23],
+            [26],
+            [29],
+            [30],
+            [31],
+        ];
+    }
+
+    /**
+     * @testCase     testIsNotSquarefreeInteger
+     * @dataProvider dataProviderForNonSquarefreeIntegers
+     * @param        int $n
+     * @throws       \Exception
+     */
+    public function testIsNotSquarefreeInteger(int $n)
+    {
+        $isSquarefreeInteger = Integer::isSquarefreeInteger($n);
+        $this->assertFalse($isSquarefreeInteger);
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderForNonSquarefreeIntegers(): array
+    {
+        return [
+            [-1],
+            [0],
+            [2*2],
+            [2*2*2],
+            [2*3*3],
+            [2*3*5*7*11*13*17*17],
+        ];
+    }
+
+    /**
      * @testCase     testSumOfDivisors
      * @dataProvider dataProviderForSumOfDivisors
      * @param        int $n

--- a/tests/NumberTheory/IntegerTest.php
+++ b/tests/NumberTheory/IntegerTest.php
@@ -218,6 +218,148 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
     }
  
     /**
+     * @testCase     isRefactorableNumber returns true if n is a refactorable number
+     * @dataProvider dataProviderForRefactorableNumbers
+     * @param        int   $n
+     * @throws       \Exception
+     */
+    public function testIsRefactorableNumber(int $n)
+    {
+        // When
+        $isRefactorableNumber = Integer::isRefactorableNumber($n);
+
+        // Then
+        $this->assertTrue($isRefactorableNumber);
+    }
+
+    /**
+     * A033950 Refactorable numbers: number of divisors of n divides n. Also known as tau numbers.
+     * @see    https://oeis.org/A033950
+     * @return array
+     */
+    public function dataProviderForRefactorableNumbers(): array
+    {
+        return [
+            [1],
+            [2],
+            [8],
+            [9],
+            [12],
+            [18],
+            [24],
+            [36],
+            [40],
+            [56],
+            [60],
+            [72],
+            [80],
+            [84],
+            [88],
+        ];
+    }
+
+    /**
+     * @testCase     isNotRefactorableNumber returns true if n is not a refactorable number
+     * @dataProvider dataProviderForNonRefactorableNumbers
+     * @param        int   $n
+     * @throws       \Exception
+     */
+    public function testIsNotRefactorableNumber(int $n)
+    {
+        // When
+        $isRefactorableNumber = Integer::isRefactorableNumber($n);
+
+        // Then
+        $this->assertFalse($isRefactorableNumber);
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderForNonRefactorableNumbers(): array
+    {
+        return [
+            [-1],
+            [0],
+            [3],
+            [10],
+            [13],
+            [17],
+        ];
+    }
+
+    /**
+     * @testCase     testIsSphericNumber
+     * @dataProvider dataProviderForSphericNumbers
+     * @param        int $n
+     * @throws       \Exception
+     */
+    public function testIsSphericNumber(int $n)
+    {
+        $isSphericNumber = Integer::isSphericNumber($n);
+        $this->assertTrue($isSphericNumber);
+    }
+
+    /**
+     * A007304 Spheric numbers: products of 3 distinct primes
+     * @see    https://oeis.org/A007304
+     * @return array
+     */
+    public function dataProviderForSphericNumbers(): array
+    {
+        return [
+            [30],
+            [42],
+            [66],
+            [70],
+            [78],
+            [102],
+            [105],
+            [110],
+            [114],
+            [130],
+            [138],
+            [154],
+            [165],
+            [170],
+            [174],
+            [182],
+            [186],
+            [190],
+            [195],
+        ];
+    }
+
+    /**
+     * @testCase     testIsNotSphericNumber
+     * @dataProvider dataProviderForNonSphericNumbers
+     * @param        int $n
+     * @throws       \Exception
+     */
+    public function testIsNotSphericNumber(int $n)
+    {
+        // When
+        $isSphericNumber = Integer::isSphericNumber($n);
+        
+        // Then
+        $this->assertFalse($isSphericNumber);
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderForNonSphericNumbers(): array
+    {
+        return [
+            [2],
+            [2 * 3],
+            [2 * 2 * 2],
+            [2 * 2 * 3 * 5],
+            [2 * 3 * 5 * 7],
+        ];
+    }
+
+    /**
      * @testCase     aliquotSum returns the sum of all proper divisors of n
      * @dataProvider dataProviderForAliquotSums
      * @param        int   $n

--- a/tests/NumberTheory/IntegerTest.php
+++ b/tests/NumberTheory/IntegerTest.php
@@ -442,6 +442,7 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
      * @testCase     testRadical
      * @dataProvider dataProviderForRadical
      * @param        int $n
+     * @param        int $expected
      * @throws       \Exception
      */
     public function testRadical(int $n, int $expected)
@@ -500,6 +501,8 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
      * @testCase     testTotient
      * @dataProvider dataProviderForTotient
      * @param        int $n
+     * @param        int $k
+     * @param        int $expected
      * @throws       \Exception
      */
     public function testTotient(int $n, int $k, int $expected)
@@ -561,24 +564,44 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testCase     totient throws an OutOfBoundsException if n is < 1.
-     * @dataProvider dataProviderForPrimeFactorizationOutOfBoundsException
+     * @testCase     totient throws an OutOfBoundsException if n is < 1 or k is < 1.
+     * @dataProvider dataProviderForTotientOutOfBoundsException
      * @param        int $n
+     * @param        int $k
      * @throws       \Exception
      */
-    public function testTotientOutOfBoundsException(int $n)
+    public function testTotientOutOfBoundsException(int $n, int $k)
     {
         // When
         $this->expectException(Exception\OutOfBoundsException::class);
 
         // Then
-        Integer::totient($n);
+        Integer::totient($n, $k);
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderForTotientOutOfBoundsException(): array
+    {
+        return [
+            [2, -1],
+            [2, 0],
+            [0, 0],
+            [0, 1],
+            [-1, -1],
+            [-1, 1],
+            [-2, 1],
+            [-100, 1],
+            [-98352299832, 1],
+        ];
     }
 
     /**
      * @testCase     testCototient
      * @dataProvider dataProviderForCototient
      * @param        int $n
+     * @param        int $expected
      * @throws       \Exception
      */
     public function testCototient(int $n, int $expected)
@@ -638,6 +661,7 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
      * @testCase     testReducedTotient
      * @dataProvider dataProviderForReducedTotient
      * @param        int $n
+     * @param        int $expected
      * @throws       \Exception
      */
     public function testReducedTotient(int $n, int $expected)
@@ -697,6 +721,7 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
      * @testCase     testMobius
      * @dataProvider dataProviderForMobius
      * @param        int $n
+     * @param        int $expected
      * @throws       \Exception
      */
     public function testMobius(int $n, int $expected)
@@ -750,15 +775,15 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testCase     testIsSquarefreeInteger
+     * @testCase     testIsSquarefree
      * @dataProvider dataProviderForSquarefreeIntegers
      * @param        int $n
      * @throws       \Exception
      */
-    public function testIsSquarefreeInteger(int $n)
+    public function testIsSquarefree(int $n)
     {
-        $isSquarefreeInteger = Integer::isSquarefreeInteger($n);
-        $this->assertTrue($isSquarefreeInteger);
+        $isSquarefree = Integer::isSquarefree($n);
+        $this->assertTrue($isSquarefree);
     }
 
     /**
@@ -793,15 +818,15 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testCase     testIsNotSquarefreeInteger
+     * @testCase     testIsNotSquarefree
      * @dataProvider dataProviderForNonSquarefreeIntegers
      * @param        int $n
      * @throws       \Exception
      */
-    public function testIsNotSquarefreeInteger(int $n)
+    public function testIsNotSquarefree(int $n)
     {
-        $isSquarefreeInteger = Integer::isSquarefreeInteger($n);
-        $this->assertFalse($isSquarefreeInteger);
+        $isSquarefree = Integer::isSquarefree($n);
+        $this->assertFalse($isSquarefree);
     }
 
     /**
@@ -823,6 +848,7 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
      * @testCase     testSumOfDivisors
      * @dataProvider dataProviderForSumOfDivisors
      * @param        int $n
+     * @param        int $expected
      * @throws       \Exception
      */
     public function testSumOfDivisors(int $n, int $expected)
@@ -881,6 +907,7 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
      * @testCase     testNumberOfDivisors
      * @dataProvider dataProviderForNumberOfDivisors
      * @param        int $n
+     * @param        int $expected
      * @throws       \Exception
      */
     public function testNumberOfDivisors(int $n, int $expected)

--- a/tests/NumberTheory/IntegerTest.php
+++ b/tests/NumberTheory/IntegerTest.php
@@ -78,6 +78,118 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
+
+    /**
+     * @testCase     testSumOfDivisors
+     * @dataProvider dataProviderForSumOfDivisors
+     * @param        int $n
+     * @throws       \Exception
+     */
+    public function testSumOfDivisors(int $n, int $expected)
+    {
+        // When
+        $actual = Integer::sumOfDivisors($n);
+        
+        // Then
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * A000203 the sum of the divisors of n
+     * @see    https://oeis.org/A000203
+     * @return array
+     */
+    public function dataProviderForSumOfDivisors(): array
+    {
+        return [
+            [1, 1],
+            [2, 3],
+            [3, 4],
+            [4, 7],
+            [5, 6],
+            [6, 12],
+            [7, 8],
+            [8, 15],
+            [9, 13],
+            [10, 18],
+            [11, 12],
+            [12, 28],
+            [13, 14],
+            [14, 24],
+            [15, 24],
+            [70, 144],
+            [44100, 160797],
+        ];
+    }
+
+    /**
+     * @testCase     sumOfDivisors throws an OutOfBoundsException if n is < 1.
+     * @dataProvider dataProviderForPrimeFactorizationOutOfBoundsException
+     * @param        int $n
+     * @throws       \Exception
+     */
+    public function testSumOfDivisorsOutOfBoundsException(int $n)
+    {
+        // When
+        $this->expectException(Exception\OutOfBoundsException::class);
+
+        // Then
+        Integer::sumOfDivisors($n);
+    }
+
+    /**
+     * @testCase     testNumberOfDivisors
+     * @dataProvider dataProviderForNumberOfDivisors
+     * @param        int $n
+     * @throws       \Exception
+     */
+    public function testNumberOfDivisors(int $n, int $expected)
+    {
+        // When
+        $actual = Integer::numberOfDivisors($n);
+        
+        // Then
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * A000005 the numbers of divisors of n
+     * @see    https://oeis.org/A000005
+     * @return array
+     */
+    public function dataProviderForNumberOfDivisors(): array
+    {
+        return [
+            [1, 1],
+            [2, 2],
+            [3, 2],
+            [4, 3],
+            [5, 2],
+            [6, 4],
+            [7, 2],
+            [8, 4],
+            [9, 3],
+            [10, 4],
+            [96, 12],
+            [103, 2],
+        ];
+    }
+
+    /**
+     * @testCase     numberOfDivisors throws an OutOfBoundsException if n is < 1.
+     * @dataProvider dataProviderForPrimeFactorizationOutOfBoundsException
+     * @param        int $n
+     * @throws       \Exception
+     */
+    public function testNumberOfDivisorsOutOfBoundsException(int $n)
+    {
+        // When
+        $this->expectException(Exception\OutOfBoundsException::class);
+
+        // Then
+        Integer::numberOfDivisors($n);
+    }
+
     /**
      * @testCase     isPerfectPower returns true if n is a perfect prime.
      * @dataProvider dataProviderForIsPerfectPower
@@ -362,6 +474,7 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
     public function dataProviderForPrimeFactorization(): array
     {
         return [
+            [1, []],
             [2, [2]],
             [3, [3]],
             [4, [2, 2]],
@@ -404,7 +517,7 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testCase     primeFactorization throws an OutOfBoundsException if n is < 2.
+     * @testCase     primeFactorization throws an OutOfBoundsException if n is < 1.
      * @dataProvider dataProviderForPrimeFactorizationOutOfBoundsException
      * @param        int $n
      * @throws       \Exception
@@ -424,7 +537,6 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
     public function dataProviderForPrimeFactorizationOutOfBoundsException(): array
     {
         return [
-            [1],
             [0],
             [-1],
             [-2],

--- a/tests/NumberTheory/IntegerTest.php
+++ b/tests/NumberTheory/IntegerTest.php
@@ -277,7 +277,7 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
             [34, 20],
             [35, 13],
             [36, 55],
-            [2*3*5*7*11, 4602],
+            [2 * 3 * 5 * 7 * 11, 4602],
         ];
     }
 
@@ -304,7 +304,7 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
      */
     public function testRadical(int $n, int $expected)
     {
-        $radical= Integer::radical($n);
+        $radical = Integer::radical($n);
         $this->assertEquals($expected, $radical);
     }
 
@@ -552,6 +552,62 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @testCase     testMobius
+     * @dataProvider dataProviderForMobius
+     * @param        int $n
+     * @throws       \Exception
+     */
+    public function testMobius(int $n, int $expected)
+    {
+        // When
+        $actual = Integer::mobius($n);
+        
+        // Then
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * A008683
+     * @see    https://oeis.org/A008683
+     * @return array
+     */
+    public function dataProviderForMobius(): array
+    {
+        return [
+            [1, 1],
+            [2, -1],
+            [3, -1],
+            [4, 0],
+            [5, -1],
+            [6, 1],
+            [7, -1],
+            [8, 0],
+            [9, 0],
+            [10, 1],
+            [11, -1],
+            [12, 0],
+            [13, -1],
+            [14, 1],
+            [15, 1],
+        ];
+    }
+
+    /**
+     * @testCase     mobius throws an OutOfBoundsException if n is < 1.
+     * @dataProvider dataProviderForPrimeFactorizationOutOfBoundsException
+     * @param        int $n
+     * @throws       \Exception
+     */
+    public function testMobiusOutOfBoundsException(int $n)
+    {
+        // When
+        $this->expectException(Exception\OutOfBoundsException::class);
+
+        // Then
+        Integer::mobius($n);
+    }
+
+    /**
      * @testCase     testIsSquarefreeInteger
      * @dataProvider dataProviderForSquarefreeIntegers
      * @param        int $n
@@ -614,10 +670,10 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
         return [
             [-1],
             [0],
-            [2*2],
-            [2*2*2],
-            [2*3*3],
-            [2*3*5*7*11*13*17*17],
+            [2 * 2],
+            [2 * 2 * 2],
+            [2 * 3 * 3],
+            [2 * 3 * 5 * 7 * 11 * 13 * 17 * 17],
         ];
     }
 

--- a/tests/NumberTheory/IntegerTest.php
+++ b/tests/NumberTheory/IntegerTest.php
@@ -353,6 +353,204 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
         Integer::radical($n);
     }
 
+
+    /**
+     * @testCase     testTotient
+     * @dataProvider dataProviderForTotient
+     * @param        int $n
+     * @throws       \Exception
+     */
+    public function testTotient(int $n, int $k, int $expected)
+    {
+        $totient = Integer::totient($n, $k);
+        $this->assertEquals($expected, $totient);
+    }
+
+    /**
+     * @see    https://oeis.org/A000010 (k=1)
+     * @see    https://oeis.org/A007434 (k=2)
+     * @see    https://oeis.org/A059376 (k=3)
+     * @see    https://oeis.org/A059377 (k=4)
+     * @see    https://oeis.org/A059378 (k=5)
+     * @return array
+     */
+    public function dataProviderForTotient(): array
+    {
+        return [
+            [1,  1, 1],
+            [2,  1, 1],
+            [3,  1, 2],
+            [4,  1, 2],
+            [5,  1, 4],
+            [6,  1, 2],
+            [7,  1, 6],
+            [8,  1, 4],
+            [9,  1, 6],
+            [10, 1, 4],
+            [11, 1, 10],
+            [12, 1, 4],
+            [13, 1, 12],
+            [14, 1, 6],
+            [15, 1, 8],
+            [16, 1, 8],
+            [17, 1, 16],
+            [18, 1, 6],
+            [1,  2, 1],
+            [2,  2, 3],
+            [3,  2, 8],
+            [4,  2, 12],
+            [5,  2, 24],
+            [6,  2, 24],
+            [7,  2, 48],
+            [8,  2, 48],
+            [9,  2, 72],
+            [10, 2, 72],
+            [1,  3, 1],
+            [2,  3, 7],
+            [3,  3, 26],
+            [4,  3, 56],
+            [5,  3, 124],
+            [6,  3, 182],
+            [7,  3, 342],
+            [8,  3, 448],
+            [9,  3, 702],
+            [10, 3, 868],
+        ];
+    }
+
+    /**
+     * @testCase     totient throws an OutOfBoundsException if n is < 1.
+     * @dataProvider dataProviderForPrimeFactorizationOutOfBoundsException
+     * @param        int $n
+     * @throws       \Exception
+     */
+    public function testTotientOutOfBoundsException(int $n)
+    {
+        // When
+        $this->expectException(Exception\OutOfBoundsException::class);
+
+        // Then
+        Integer::totient($n);
+    }
+
+    /**
+     * @testCase     testCototient
+     * @dataProvider dataProviderForCototient
+     * @param        int $n
+     * @throws       \Exception
+     */
+    public function testCototient(int $n, int $expected)
+    {
+        $cototient = Integer::cototient($n);
+        $this->assertEquals($expected, $cototient);
+    }
+
+    /**
+     * A051953 n - φ(n)
+     * @see    https://oeis.org/A051953
+     * @return array
+     */
+    public function dataProviderForCototient(): array
+    {
+        return [
+            [1,  0],
+            [2,  1],
+            [3,  1],
+            [4,  2],
+            [5,  1],
+            [6,  4],
+            [7,  1],
+            [8,  4],
+            [9,  3],
+            [10, 6],
+            [11, 1],
+            [12, 8],
+            [13, 1],
+            [14, 8],
+            [15, 7],
+            [16, 8],
+            [17, 1],
+            [18, 12],
+            [19, 1],
+            [20, 12],
+            [80, 48],
+        ];
+    }
+
+    /**
+     * @testCase     cototient throws an OutOfBoundsException if n is < 1.
+     * @dataProvider dataProviderForPrimeFactorizationOutOfBoundsException
+     * @param        int $n
+     * @throws       \Exception
+     */
+    public function testCototientOutOfBoundsException(int $n)
+    {
+        // When
+        $this->expectException(Exception\OutOfBoundsException::class);
+
+        // Then
+        Integer::cototient($n);
+    }
+
+    /**
+     * @testCase     testReducedTotient
+     * @dataProvider dataProviderForReducedTotient
+     * @param        int $n
+     * @throws       \Exception
+     */
+    public function testReducedTotient(int $n, int $expected)
+    {
+        $result = Integer::reducedTotient($n);
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @see    https://oeis.org/A002322
+     * @return array
+     */
+    public function dataProviderForReducedTotient(): array
+    {
+        return [
+            [1,  1],
+            [2,  1],
+            [3,  2],
+            [4,  2],
+            [5,  4],
+            [6,  2],
+            [7,  6],
+            [8,  2],
+            [9,  6],
+            [10, 4],
+            [11, 10],
+            [12, 2],
+            [13, 12],
+            [14, 6],
+            [15, 4],
+            [16, 4],
+            [17, 16],
+            [18, 6],
+            [19, 18],
+            [64, 16],
+            [80, 4],
+            [81, 54],
+        ];
+    }
+
+    /**
+     * @testCase     reducedTotient throws an OutOfBoundsException if n is < 1.
+     * @dataProvider dataProviderForPrimeFactorizationOutOfBoundsException
+     * @param        int $n
+     * @throws       \Exception
+     */
+    public function testReducedTotientOutOfBoundsException(int $n)
+    {
+        // When
+        $this->expectException(Exception\OutOfBoundsException::class);
+
+        // Then
+        Integer::reducedTotient($n);
+    }
+
     /**
      * @testCase     testIsSquarefreeInteger
      * @dataProvider dataProviderForSquarefreeIntegers

--- a/tests/NumberTheory/IntegerTest.php
+++ b/tests/NumberTheory/IntegerTest.php
@@ -41,6 +41,9 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
     /**
      * @testCase     isPerfectNumber is not a perfect number
      * @dataProvider dataProviderForNonPerfectNumbers
+     * @dataProvider dataProviderForAbundantNumbers
+     * @dataProvider dataProviderForDeficientNumbers
+     * @dataProvider dataProviderForPrimeFactorizationOutOfBoundsException
      * @param        int $n
      */
     public function testIsNotPerfectNumber(int $n)
@@ -78,6 +81,220 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
+    /**
+     * @testCase     isAbundantNumber returns true if n is an abundant number
+     * @dataProvider dataProviderForAbundantNumbers
+     * @param        int   $n
+     * @throws       \Exception
+     */
+    public function testIsAbundantNumber(int $n)
+    {
+        // When
+        $isAbundantNumber = Integer::isAbundantNumber($n);
+
+        // Then
+        $this->assertTrue($isAbundantNumber);
+    }
+
+    /**
+     * A005101 abundant numbers: numbers n such that σ₁(n) > 2n
+     * @see    https://oeis.org/A005101
+     * @return array
+     */
+    public function dataProviderForAbundantNumbers(): array
+    {
+        return [
+            [12],
+            [18],
+            [20],
+            [24],
+            [30],
+            [36],
+            [40],
+            [42],
+            [48],
+            [54],
+            [56],
+            [60],
+            [66],
+            [70],
+            [72],
+            [78],
+            [80],
+            [84],
+            [88],
+            [90],
+            [96],
+            [100],
+            [102],
+            [104],
+            [270],
+        ];
+    }
+
+    /**
+     * @testCase     isNotAbundantNumber returns true if n is not an abundant number
+     * @dataProvider dataProviderForDeficientNumbers
+     * @dataProvider dataProviderForPerfectNumbers
+     * @dataProvider dataProviderForPrimeFactorizationOutOfBoundsException
+     * @param        int   $n
+     * @throws       \Exception
+     */
+    public function testIsNotAbundantNumber(int $n)
+    {
+        // When
+        $isAbundantNumber = Integer::isAbundantNumber($n);
+
+        // Then
+        $this->assertFalse($isAbundantNumber);
+    }
+
+    /**
+     * @testCase     isDeficientNumber returns true if n is a deficient number
+     * @dataProvider dataProviderForDeficientNumbers
+     * @param        int   $n
+     * @throws       \Exception
+     */
+    public function testIsDeficientNumber(int $n)
+    {
+        // When
+        $isDeficientNumber = Integer::isDeficientNumber($n);
+
+        // Then
+        $this->assertTrue($isDeficientNumber);
+    }
+
+    /**
+     * A005100 deficient numbers: numbers n such that σ₁(n) < 2n
+     * @see    https://oeis.org/A005100
+     * @return array
+     */
+    public function dataProviderForDeficientNumbers(): array
+    {
+        return [
+            [1],
+            [2],
+            [3],
+            [4],
+            [5],
+            [7],
+            [8],
+            [9],
+            [10],
+            [11],
+            [13],
+            [14],
+            [15],
+            [16],
+            [17],
+            [19],
+            [21],
+            [22],
+            [23],
+            [25],
+            [26],
+            [27],
+            [29],
+            [31],
+            [32],
+        ];
+    }
+
+    /**
+     * @testCase     isNotDeficientNumber returns true if n is not a deficient number
+     * @dataProvider dataProviderForAbundantNumbers
+     * @dataProvider dataProviderForPerfectNumbers
+     * @dataProvider dataProviderForPrimeFactorizationOutOfBoundsException
+     * @param        int   $n
+     * @throws       \Exception
+     */
+    public function testIsNotDeficientNumber(int $n)
+    {
+        // When
+        $isDeficientNumber = Integer::isDeficientNumber($n);
+
+        // Then
+        $this->assertFalse($isDeficientNumber);
+    }
+ 
+    /**
+     * @testCase     aliquotSum returns the sum of all proper divisors of n
+     * @dataProvider dataProviderForAliquotSums
+     * @param        int   $n
+     * @param        int   $expected
+     * @throws       \Exception
+     */
+    public function testAliquotSum(int $n, int $expected)
+    {
+        // When
+        $actual = Integer::aliquotSum($n);
+
+        // Then
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * A001065 sum of proper divisors (or aliquot parts) of n
+     * @see    https://oeis.org/A001065
+     * @return array
+     */
+    public function dataProviderForAliquotSums(): array
+    {
+        return [
+            [1, 0],
+            [2, 1],
+            [3, 1],
+            [4, 3],
+            [5, 1],
+            [6, 6],
+            [7, 1],
+            [8, 7],
+            [9, 4],
+            [10, 8],
+            [11, 1],
+            [12, 16],
+            [13, 1],
+            [14, 10],
+            [15, 9],
+            [16, 15],
+            [17, 1],
+            [18, 21],
+            [19, 1],
+            [20, 22],
+            [21, 11],
+            [22, 14],
+            [23, 1],
+            [24, 36],
+            [25, 6],
+            [26, 16],
+            [27, 13],
+            [28, 28],
+            [29, 1],
+            [30, 42],
+            [31, 1],
+            [32, 31],
+            [33, 15],
+            [34, 20],
+            [35, 13],
+            [36, 55],
+            [2*3*5*7*11, 4602],
+        ];
+    }
+
+    /**
+     * @testCase     aliquotSum throws an OutOfBoundsException if n is < 1.
+     * @dataProvider dataProviderForPrimeFactorizationOutOfBoundsException
+     * @param        int $n
+     * @throws       \Exception
+     */
+    public function testAliquotSumOutOfBoundsException(int $n)
+    {
+        // When
+        $this->expectException(Exception\OutOfBoundsException::class);
+
+        // Then
+        Integer::aliquotSum($n);
+    }
 
     /**
      * @testCase     testSumOfDivisors


### PR DESCRIPTION
This adds the following functions:
- `Integer::numberOfDivisors($n)`
- `Integer::sumOfDivisors($n)`
- `Integer::aliquotSum($n)`
- `Integer::isAbundantNumber($n)`
- `Integer::isDeficientNumber($n)`
- `Integer::radical($n)`
- `Integer::isSquarefreeInteger($n)`
- `Integer::totient($n, $k = 1)`
- `Integer::cototient($n)`
- `Integer::reducedTotient($n)`
- `Integer::mobius($n)`
- `Integer::isRefactorableNumber($n)`
- `Integer::isSphenicNumber($n)`

It refactors `Integer::isPerfectNumber($n)` to work off the prime factorization. With the optimization for prime factorization applied, this reduces testing 2...1e6 from ~33.54s to ~5.14s omm.

One backward incompatibility is `Integer::primeFactorization` will now return `[]` (https://en.wikipedia.org/wiki/Empty_product) as the prime factorization of 1 instead of throwing an exception. 