### PR TITLE
getCereals() was not covered.

### DIFF
--- a/tests/SampleData/CerealTest.php
+++ b/tests/SampleData/CerealTest.php
@@ -20,14 +20,16 @@ class CerealTest extends \PHPUnit\Framework\TestCase
     public function testDataObservations()
     {
         // When
-        $X   = $this->cereal->getXData();
-        $Y   = $this->cereal->getYData();
-        $Ysc = $this->cereal->getYscData();
+        $X     = $this->cereal->getXData();
+        $Y     = $this->cereal->getYData();
+        $Ysc   = $this->cereal->getYscData();
+        $names = $this->cereal->getCereals();
 
         // Then
         $this->assertCount(15, $X);
         $this->assertCount(15, $Y);
-        $this->assertCount(15, $Y);
+        $this->assertCount(15, $Ysc);
+        $this->assertCount(15, $names);
     }
 
     /**


### PR DESCRIPTION
And Y was tested twice in lieu of Ysc.