### PR TITLE
Permutation precision error

### DIFF
--- a/src/Probability/Combinatorics.php
+++ b/src/Probability/Combinatorics.php
@@ -239,16 +239,17 @@ class Combinatorics
             throw new Exception\OutOfBoundsException('k cannot be larger than n.');
         }
 
-        $n！ = self::factorial($n);
-
         // nPn: permutations of n things, taken n at a time
         if (is_null($k)) {
-            return $n！;
+            return $self::factorial($n);
         }
 
         // nPk: Permutations of n things taking only k of them
-        $⟮n − k⟯！ = self::factorial($n - $k);
-        return $n！ / $⟮n − k⟯！;
+        $falling_factorial = 1;
+        for ($i = $n - $k + 1; $i <= $n; $i++) {
+            $falling_factorial *= $i;
+        }
+        return $falling_factorial;
     }
 
     /**

--- a/src/Probability/Combinatorics.php
+++ b/src/Probability/Combinatorics.php
@@ -241,7 +241,7 @@ class Combinatorics
 
         // nPn: permutations of n things, taken n at a time
         if (is_null($k)) {
-            return $self::factorial($n);
+            return self::factorial($n);
         }
 
         // nPk: Permutations of n things taking only k of them

--- a/tests/Probability/CombinatoricsTest.php
+++ b/tests/Probability/CombinatoricsTest.php
@@ -332,6 +332,7 @@ class CombinatoricsTest extends \PHPUnit\Framework\TestCase
             [ 6,  4,     360],
             [16,  3,    3360],
             [20,  3,    6840],
+            [23,  5, 4037880],
         ];
     }
 


### PR DESCRIPTION
Preventing the factorial from overflowing.