### PR TITLE
Add row/columnAddVector to NumericMatrix

### DIFF
--- a/src/LinearAlgebra/NumericMatrix.php
+++ b/src/LinearAlgebra/NumericMatrix.php
@@ -2554,6 +2554,7 @@ class NumericMatrix extends Matrix
      * COLUMN OPERATIONS - Return a Matrix
      *  - columnMultiply
      *  - columnAdd
+     *  - columnAddVector
      **************************************************************************/
 
     /**
@@ -2612,6 +2613,40 @@ class NumericMatrix extends Matrix
 
         for ($i = 0; $i < $m; $i++) {
             $R[$i][$nⱼ] += $R[$i][$nᵢ] * $k;
+        }
+
+        return MatrixFactory::createNumeric($R, $this->ε);
+    }
+
+    /**
+     * Add components of vector v to column nᵢ
+     *
+     * @param Vector $v Vector to add to column nᵢ
+     * @param int    $nᵢ Column to add vector $v to
+     *
+     * @return NumericMatrix
+     *
+     * @throws Exception\MatrixException if column to add does not exist
+     * @throws Exception\BadParameterException if the vector is 0-length (±ε) or has a different # of components to the # of rows
+     * @throws Exception\IncorrectTypeException
+     */
+    public function columnAddVector(Vector $v, int $nᵢ): NumericMatrix
+    {
+        if ($nᵢ < 0 || $nᵢ >= $this->n) {
+            throw new Exception\MatrixException('Column to add does not exist');
+        }
+        if (Support::isEqual((float) $v->length(), 0, $this->ε)) {
+            throw new Exception\BadParameterException('Cannot add a 0-length vector');
+        }
+        if ($v->count() !== $this->m) {
+            throw new Exception\BadParameterException('Vector is not the same length as matrix rows');
+        }
+
+        $m = $this->m;
+        $R = $this->A;
+
+        for ($i = 0; $i < $m; $i++) {
+            $R[$i][$nᵢ] += $v[$i];
         }
 
         return MatrixFactory::createNumeric($R, $this->ε);

--- a/src/LinearAlgebra/NumericMatrix.php
+++ b/src/LinearAlgebra/NumericMatrix.php
@@ -2503,16 +2503,13 @@ class NumericMatrix extends Matrix
      * @return NumericMatrix
      *
      * @throws Exception\MatrixException if row to add does not exist
-     * @throws Exception\BadParameterException if the vector is 0-length (±ε) or has a different # of components to the # of columns
+     * @throws Exception\BadParameterException if the vector has a different # of components to the # of columns
      * @throws Exception\IncorrectTypeException
      */
     public function rowAddVector(Vector $v, int $mᵢ): NumericMatrix
     {
         if ($mᵢ < 0 || $mᵢ >= $this->m) {
             throw new Exception\MatrixException('Row to add does not exist');
-        }
-        if (Support::isEqual((float) $v->length(), 0, $this->ε)) {
-            throw new Exception\BadParameterException('Cannot add a 0-length vector');
         }
         if ($v->count() !== $this->m) {
             throw new Exception\BadParameterException('Vector is not the same length as matrix columns');
@@ -2662,16 +2659,13 @@ class NumericMatrix extends Matrix
      * @return NumericMatrix
      *
      * @throws Exception\MatrixException if column to add does not exist
-     * @throws Exception\BadParameterException if the vector is 0-length (±ε) or has a different # of components to the # of rows
+     * @throws Exception\BadParameterException if the vector has a different # of components to the # of rows
      * @throws Exception\IncorrectTypeException
      */
     public function columnAddVector(Vector $v, int $nᵢ): NumericMatrix
     {
         if ($nᵢ < 0 || $nᵢ >= $this->n) {
             throw new Exception\MatrixException('Column to add does not exist');
-        }
-        if (Support::isEqual((float) $v->length(), 0, $this->ε)) {
-            throw new Exception\BadParameterException('Cannot add a 0-length vector');
         }
         if ($v->count() !== $this->m) {
             throw new Exception\BadParameterException('Vector is not the same length as matrix rows');

--- a/src/LinearAlgebra/NumericMatrix.php
+++ b/src/LinearAlgebra/NumericMatrix.php
@@ -2366,6 +2366,7 @@ class NumericMatrix extends Matrix
      *  - rowDivide
      *  - rowAdd
      *  - rowAddScalar
+     *  - rowAddVector
      *  - rowSubtract
      *  - rowSubtractScalar
      **************************************************************************/
@@ -2488,6 +2489,40 @@ class NumericMatrix extends Matrix
 
         for ($j = 0; $j < $n; $j++) {
             $R[$mᵢ][$j] += $k;
+        }
+
+        return MatrixFactory::createNumeric($R, $this->ε);
+    }
+
+    /**
+     * Add components of vector v to row mᵢ
+     *
+     * @param Vector $v Vector to add to row mᵢ
+     * @param int    $mᵢ Row to add vector $v to
+     *
+     * @return NumericMatrix
+     *
+     * @throws Exception\MatrixException if row to add does not exist
+     * @throws Exception\BadParameterException if the vector is 0-length (±ε) or has a different # of components to the # of columns
+     * @throws Exception\IncorrectTypeException
+     */
+    public function rowAddVector(Vector $v, int $mᵢ): NumericMatrix
+    {
+        if ($mᵢ < 0 || $mᵢ >= $this->m) {
+            throw new Exception\MatrixException('Row to add does not exist');
+        }
+        if (Support::isEqual((float) $v->length(), 0, $this->ε)) {
+            throw new Exception\BadParameterException('Cannot add a 0-length vector');
+        }
+        if ($v->count() !== $this->m) {
+            throw new Exception\BadParameterException('Vector is not the same length as matrix columns');
+        }
+
+        $n = $this->n;
+        $R = $this->A;
+
+        for ($j = 0; $j < $n; $j++) {
+            $R[$mᵢ][$j] += $v[$j];
         }
 
         return MatrixFactory::createNumeric($R, $this->ε);

--- a/tests/LinearAlgebra/Matrix/Numeric/MatrixColumnOperationsTest.php
+++ b/tests/LinearAlgebra/Matrix/Numeric/MatrixColumnOperationsTest.php
@@ -340,4 +340,26 @@ class MatrixColumnOperationsTest extends \PHPUnit\Framework\TestCase
         // When
         $A->columnAddVector($b, 4);
     }
+
+    /**
+     * @test   columnAddVector test vector is not a zero-vector
+     * @throws \Exception
+     */
+    public function testColumnAddVectorExceptionZeroVector()
+    {
+        // Given
+        $A = MatrixFactory::createNumeric([
+            [1, 2, 3],
+            [2, 3, 4],
+            [3, 4, 5],
+        ]);
+
+        $b = new Vector([0,0,0]);
+
+        // Then
+        $this->expectException(Exception\BadParameterException::class);
+
+        // When
+        $A->columnAddVector($b, 0);
+    }
 }

--- a/tests/LinearAlgebra/Matrix/Numeric/MatrixColumnOperationsTest.php
+++ b/tests/LinearAlgebra/Matrix/Numeric/MatrixColumnOperationsTest.php
@@ -318,4 +318,26 @@ class MatrixColumnOperationsTest extends \PHPUnit\Framework\TestCase
             ],
         ];
     }
+
+    /**
+     * @test   columnAddVector test column n exists
+     * @throws \Exception
+     */
+    public function testColumnAddVectorExceptionColumnExists()
+    {
+        // Given
+        $A = MatrixFactory::createNumeric([
+            [1, 2, 3],
+            [2, 3, 4],
+            [3, 4, 5],
+        ]);
+
+        $b = new Vector([1,2,3]);
+
+        // Then
+        $this->expectException(Exception\MatrixException::class);
+
+        // When
+        $A->columnAddVector($b, 4);
+    }
 }

--- a/tests/LinearAlgebra/Matrix/Numeric/MatrixColumnOperationsTest.php
+++ b/tests/LinearAlgebra/Matrix/Numeric/MatrixColumnOperationsTest.php
@@ -367,7 +367,7 @@ class MatrixColumnOperationsTest extends \PHPUnit\Framework\TestCase
      * @test   columnAddVector test Vector->count() === matrix->m
      * @throws \Exception
      */
-    public function testColumnAddVectorExceptionLengthMismatch()
+    public function testColumnAddVectorExceptionElementMismatch()
     {
         // Given
         $A = MatrixFactory::createNumeric([

--- a/tests/LinearAlgebra/Matrix/Numeric/MatrixColumnOperationsTest.php
+++ b/tests/LinearAlgebra/Matrix/Numeric/MatrixColumnOperationsTest.php
@@ -362,4 +362,26 @@ class MatrixColumnOperationsTest extends \PHPUnit\Framework\TestCase
         // When
         $A->columnAddVector($b, 0);
     }
+
+    /**
+     * @test   columnAddVector test Vector->count() === matrix->m
+     * @throws \Exception
+     */
+    public function testColumnAddVectorExceptionLengthMismatch()
+    {
+        // Given
+        $A = MatrixFactory::createNumeric([
+            [1, 2, 3],
+            [2, 3, 4],
+            [3, 4, 5],
+        ]);
+
+        $b = new Vector([1,2,3,4]);
+
+        // Then
+        $this->expectException(Exception\BadParameterException::class);
+
+        // When
+        $A->columnAddVector($b, 1);
+    }
 }

--- a/tests/LinearAlgebra/Matrix/Numeric/MatrixColumnOperationsTest.php
+++ b/tests/LinearAlgebra/Matrix/Numeric/MatrixColumnOperationsTest.php
@@ -342,28 +342,6 @@ class MatrixColumnOperationsTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @test   columnAddVector test vector is not a zero-vector
-     * @throws \Exception
-     */
-    public function testColumnAddVectorExceptionZeroVector()
-    {
-        // Given
-        $A = MatrixFactory::createNumeric([
-            [1, 2, 3],
-            [2, 3, 4],
-            [3, 4, 5],
-        ]);
-
-        $b = new Vector([0,0,0]);
-
-        // Then
-        $this->expectException(Exception\BadParameterException::class);
-
-        // When
-        $A->columnAddVector($b, 0);
-    }
-
-    /**
      * @test   columnAddVector test Vector->count() === matrix->m
      * @throws \Exception
      */

--- a/tests/LinearAlgebra/Matrix/Numeric/MatrixColumnOperationsTest.php
+++ b/tests/LinearAlgebra/Matrix/Numeric/MatrixColumnOperationsTest.php
@@ -4,6 +4,7 @@ namespace MathPHP\Tests\LinearAlgebra\Matrix\Numeric;
 
 use MathPHP\LinearAlgebra\MatrixFactory;
 use MathPHP\Exception;
+use MathPHP\LinearAlgebra\Vector;
 
 class MatrixColumnOperationsTest extends \PHPUnit\Framework\TestCase
 {
@@ -236,5 +237,85 @@ class MatrixColumnOperationsTest extends \PHPUnit\Framework\TestCase
 
         // When
         $A->columnAdd(1, 2, 0);
+    }
+
+    /**
+     * @test         columnAddVector
+     * @dataProvider dataProviderForColumnAddVector
+     * @param        array $A
+     * @param        int   $nᵢ
+     * @param        array $v
+     * @param        array $expectedMatrix
+     * @throws      \Exception
+     */
+    public function testColumnAddVector(array $A, int $nᵢ, array $v, array $expectedMatrix)
+    {
+        // Given
+        $A = MatrixFactory::createNumeric($A);
+        $v = new Vector($v);
+        $expectedMatrix = MatrixFactory::createNumeric($expectedMatrix);
+
+        // When
+        $R = $A->columnAddVector($v, $nᵢ);
+
+        // Then
+        $this->assertEquals($expectedMatrix, $R);
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderForColumnAddVector(): array
+    {
+        return [
+            [
+                [
+                    [1, 2, 3],
+                    [2, 3, 4],
+                    [3, 4, 5],
+                ], 0, [1,2,3],
+                [
+                    [2, 2, 3],
+                    [4, 3, 4],
+                    [6, 4, 5],
+                ]
+            ],
+            [
+                [
+                    [1, 2, 3],
+                    [2, 3, 4],
+                    [3, 4, 5],
+                ], 2, [6,9,12],
+                [
+                    [1, 2, 9],
+                    [2, 3, 13],
+                    [3, 4, 17],
+                ]
+            ],
+            [
+                [
+                    [1, 2, 3],
+                    [2, 3, 4],
+                    [3, 4, 5],
+                ], 2, [4,8,12],
+                [
+                    [1, 2, 7],
+                    [2, 3, 12],
+                    [3, 4, 17],
+                ]
+            ],
+            [
+                [
+                    [1, 2, 3],
+                    [2, 3, 4],
+                    [3, 4, 5],
+                ], 1, [2.2,3.3,4.4],
+                [
+                    [1, 4.2, 3],
+                    [2, 6.3, 4],
+                    [3, 8.4, 5],
+                ]
+            ],
+        ];
     }
 }

--- a/tests/LinearAlgebra/Matrix/Numeric/MatrixRowOperationsTest.php
+++ b/tests/LinearAlgebra/Matrix/Numeric/MatrixRowOperationsTest.php
@@ -512,28 +512,6 @@ class MatrixRowOperationsTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @test   rowAddVector test vector is not a zero-vector
-     * @throws \Exception
-     */
-    public function testRowAddVectorExceptionZeroVector()
-    {
-        // Given
-        $A = MatrixFactory::createNumeric([
-            [1, 2, 3],
-            [2, 3, 4],
-            [3, 4, 5],
-        ]);
-
-        $b = new Vector([0,0,0]);
-
-        // Then
-        $this->expectException(Exception\BadParameterException::class);
-
-        // When
-        $A->rowAddVector($b, 0);
-    }
-
-    /**
      * @test   rowAddVector test vector->count() === matrix m
      * @throws \Exception
      */

--- a/tests/LinearAlgebra/Matrix/Numeric/MatrixRowOperationsTest.php
+++ b/tests/LinearAlgebra/Matrix/Numeric/MatrixRowOperationsTest.php
@@ -512,6 +512,28 @@ class MatrixRowOperationsTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @test   rowAddVector test vector is not a zero-vector
+     * @throws \Exception
+     */
+    public function testRowAddVectorExceptionZeroVector()
+    {
+        // Given
+        $A = MatrixFactory::createNumeric([
+            [1, 2, 3],
+            [2, 3, 4],
+            [3, 4, 5],
+        ]);
+
+        $b = new Vector([0,0,0]);
+
+        // Then
+        $this->expectException(Exception\BadParameterException::class);
+
+        // When
+        $A->rowAddVector($b, 0);
+    }
+
+    /**
      * @test         rowSubtract
      * @dataProvider dataProviderForRowSubtract
      * @param        array $A

--- a/tests/LinearAlgebra/Matrix/Numeric/MatrixRowOperationsTest.php
+++ b/tests/LinearAlgebra/Matrix/Numeric/MatrixRowOperationsTest.php
@@ -490,6 +490,28 @@ class MatrixRowOperationsTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @test   rowAddVector test row m exists
+     * @throws \Exception
+     */
+    public function testRowAddVectorExceptionRowExists()
+    {
+        // Given
+        $A = MatrixFactory::createNumeric([
+            [1, 2, 3],
+            [2, 3, 4],
+            [3, 4, 5],
+        ]);
+
+        $b = new Vector([1,2,3]);
+
+        // Then
+        $this->expectException(Exception\MatrixException::class);
+
+        // When
+        $A->rowAddVector($b, 4);
+    }
+
+    /**
      * @test         rowSubtract
      * @dataProvider dataProviderForRowSubtract
      * @param        array $A

--- a/tests/LinearAlgebra/Matrix/Numeric/MatrixRowOperationsTest.php
+++ b/tests/LinearAlgebra/Matrix/Numeric/MatrixRowOperationsTest.php
@@ -4,6 +4,7 @@ namespace MathPHP\Tests\LinearAlgebra\Matrix\Numeric;
 
 use MathPHP\LinearAlgebra\MatrixFactory;
 use MathPHP\Exception;
+use MathPHP\LinearAlgebra\Vector;
 
 class MatrixRowOperationsTest extends \PHPUnit\Framework\TestCase
 {
@@ -406,6 +407,86 @@ class MatrixRowOperationsTest extends \PHPUnit\Framework\TestCase
 
         // Then
         $A->rowAddScalar(4, 5);
+    }
+
+    /**
+     * @test         rowAddVector
+     * @dataProvider dataProviderForrowAddVector
+     * @param        array $A
+     * @param        int   $mᵢ
+     * @param        array $v
+     * @param        array $expectedMatrix
+     * @throws      \Exception
+     */
+    public function testRowAddVector(array $A, int $mᵢ, array $v, array $expectedMatrix)
+    {
+        // Given
+        $A = MatrixFactory::createNumeric($A);
+        $v = new Vector($v);
+        $expectedMatrix = MatrixFactory::createNumeric($expectedMatrix);
+
+        // When
+        $R = $A->rowAddVector($v, $mᵢ);
+
+        // Then
+        $this->assertEquals($expectedMatrix, $R);
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderForRowAddVector(): array
+    {
+        return [
+            [
+                [
+                    [1, 2, 3],
+                    [2, 3, 4],
+                    [3, 4, 5],
+                ], 0, [1,2,3],
+                [
+                    [2, 4, 6],
+                    [2, 3, 4],
+                    [3, 4, 5],
+                ]
+            ],
+            [
+                [
+                    [1, 2, 3],
+                    [2, 3, 4],
+                    [3, 4, 5],
+                ], 2, [6,9,12],
+                [
+                    [1, 2, 3],
+                    [2, 3, 4],
+                    [9, 13, 17],
+                ]
+            ],
+            [
+                [
+                    [1, 2, 3],
+                    [2, 3, 4],
+                    [3, 4, 5],
+                ], 2, [4,8,12],
+                [
+                    [1, 2, 3],
+                    [2, 3, 4],
+                    [7, 12, 17],
+                ]
+            ],
+            [
+                [
+                    [1, 2, 3],
+                    [2, 3, 4],
+                    [3, 4, 5],
+                ], 1, [2.2,3.3,4.4],
+                [
+                    [1, 2, 3],
+                    [4.2, 6.3, 8.4],
+                    [3, 4, 5],
+                ]
+            ],
+        ];
     }
 
     /**

--- a/tests/LinearAlgebra/Matrix/Numeric/MatrixRowOperationsTest.php
+++ b/tests/LinearAlgebra/Matrix/Numeric/MatrixRowOperationsTest.php
@@ -534,6 +534,28 @@ class MatrixRowOperationsTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @test   rowAddVector test vector->count() === matrix m
+     * @throws \Exception
+     */
+    public function testRowAddVectorExceptionElementMismatch()
+    {
+        // Given
+        $A = MatrixFactory::createNumeric([
+            [1, 2, 3],
+            [2, 3, 4],
+            [3, 4, 5],
+        ]);
+
+        $b = new Vector([1,2,3,4]);
+
+        // Then
+        $this->expectException(Exception\BadParameterException::class);
+
+        // When
+        $A->rowAddVector($b, 1);
+    }
+
+    /**
      * @test         rowSubtract
      * @dataProvider dataProviderForRowSubtract
      * @param        array $A


### PR DESCRIPTION
Adds the feature discussed in #459

There are two decisions I made that you might want to consider before merging

1. At first, I decided to match the behavior of `row/columnAdd` where k is not allowed to be 0, so I added a condition to check if the given vector is a zero-vector by comparing its length to 0 (within the tolerance of the matrix). As I was writing this PR though, I realized it might best to break precedent since the user may not know the contents of the vector at run-time vs the explicit `k` passed into `row/columnAdd`. If you disagree, you can revert the last commit. However, I think there's little harm in letting it pass through, and it might be even better to keep the comparison and just return `self` to avoid adding imprecision and creating a new matrix.
2. In the tests, I used `MatrixFactory::createNumeric` to make intellisense happy 🙃
    It's inconsistent with the rest of the tests, but I figured it may not matter

Let me know of any desired changes or formatting errors, I did my best to follow the guidelines.