### PR TITLE
NonInteger::hyperharmonic(): bug fix

### DIFF
--- a/src/Sequence/NonInteger.php
+++ b/src/Sequence/NonInteger.php
@@ -104,7 +104,7 @@ class NonInteger
                     $sequence[$k] = $∑;
                 }
             }
-        } catch (\TypeError $e) {
+        } catch (\TypeError|\Error $e) {
             throw new Exception\OutOfBoundsException('Numbers too large to maintain integer precision', -1, $e);
         }
 

--- a/src/Sequence/NonInteger.php
+++ b/src/Sequence/NonInteger.php
@@ -79,6 +79,8 @@ class NonInteger
      * @param bool $rational return results as a Rational object
      *
      * @return float[]|Rational[]
+     *
+     * @throws Exception\OutOfBoundsException
      */
     public static function hyperharmonic(int $n, int $r, $rational = false): array
     {
@@ -104,8 +106,10 @@ class NonInteger
                     $sequence[$k] = $∑;
                 }
             }
-        } catch (\TypeError|\Error $e) {
+        } catch (\TypeError $e) {
             throw new Exception\OutOfBoundsException('Numbers too large to maintain integer precision', -1, $e);
+        } catch (\Error $e) {
+            throw new Exception\OutOfBoundsException("Recursion depth level error: {$e->getMessage()}", -2, $e);
         }
 
         if ($rational == true) {


### PR DESCRIPTION
`NonInteger::hyperharmonic()` bug fix: we need to catch `\Error` (not only `\TypeError`) to throw `OutOfBoundsException` instead.

I had an error in tests (using `make tests` terminal command). This patch fixes it.

Environment in which the error is reproduced: 
```
PHP 7.4.3-4ubuntu2.17 (cli) (built: Jan 10 2023 15:37:44) ( NTS )
Copyright (c) The PHP Group
Zend Engine v3.4.0, Copyright (c) Zend Technologies
    with Zend OPcache v7.4.3-4ubuntu2.17, Copyright (c), by Zend Technologies
    with Xdebug v2.9.2, Copyright (c) 2002-2020, by Derick Rethans

php > var_dump(error_reporting());
php shell code:1:
int(22527) // E_ALL & ~E_DEPRECATED & ~E_STRICT
```

![2023-01-26_13-40](https://user-images.githubusercontent.com/7403235/214819597-940b98fa-8348-4be9-b4ca-8128e852ec82.png)
