### PR TITLE
Allow sampling from uniform and categorical distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1471,6 +1471,7 @@ $probabilities = ['a' => 0.3, 'b' => 0.2, 'c' => 0.5]; // probabilities for cate
 $categorical   = new Discrete\Categorical($k, $probabilities);
 $pmf_a         = $categorical->pmf('a');
 $mode          = $categorical->mode();
+$random        = $categorical->rand(); // returns 'a' or 'b' or 'c'
 
 // Geometric distribution (failures before the first success)
 $p         = 0.5; // success probability
@@ -1549,6 +1550,7 @@ $cdf     = $uniform->cdf($k);
 $μ       = $uniform->mean();
 $median  = $uniform->median();
 $σ²      = $uniform->variance();
+$random  = $uniform->rand();
 
 // Zipf distribution
 $k    = 2;   // rank

--- a/src/Probability/Distribution/Discrete/Uniform.php
+++ b/src/Probability/Distribution/Discrete/Uniform.php
@@ -154,4 +154,14 @@ class Uniform extends Discrete
 
         return (($b - $a + 1) ** 2 - 1) / 12;
     }
+
+    /**
+     * Random number sampled from the distribution
+     *
+     * @return int
+     */
+    public function rand(): int
+    {
+        return \random_int($this->a, $this->b);
+    }
 }

--- a/tests/Probability/Distribution/Discrete/CategoricalTest.php
+++ b/tests/Probability/Distribution/Discrete/CategoricalTest.php
@@ -237,4 +237,39 @@ class CategoricalTest extends \PHPUnit\Framework\TestCase
         // When
         $does_not_exist = $categorical->does_not_exist;
     }
+
+
+    /**
+     * @test rand
+     */
+    public function testRand()
+    {
+        // Given
+        $k             = 3;
+        $probabilities = ['a' => 0.2, 'b' => 0.5, 'c' => 0.3];
+        $categorical   = new Categorical($k, $probabilities);
+
+        // When
+        $rand = $categorical->rand();
+
+        // Then
+        $this->assertContains($rand, ['a', 'b', 'c']);
+    }
+
+    /**
+     * @test rand with certainty
+     */
+    public function testRandCertain()
+    {
+        // Given
+        $k             = 3;
+        $probabilities = ['a' => 0.0, 'b' => 1.0, 'c' => 0.0];
+        $categorical   = new Categorical($k, $probabilities);
+
+        // When
+        $rand = $categorical->rand();
+
+        // Then
+        $this->assertEquals('b', $rand);
+    }
 }

--- a/tests/Probability/Distribution/Discrete/UniformTest.php
+++ b/tests/Probability/Distribution/Discrete/UniformTest.php
@@ -175,4 +175,23 @@ class UniformTest extends \PHPUnit\Framework\TestCase
             [2, 4, 0.66666666666667],
         ];
     }
+
+    /**
+     * @test rand
+     */
+    public function testRand()
+    {
+        // Given
+        $a = 10;
+        $b = 11;
+        $uniform = new Uniform($a, $b);
+
+        // When
+        $random = $uniform->rand();
+
+        // Then
+        $this->assertTrue(\is_numeric($random));
+        $this->assertTrue($a <= $random);
+        $this->assertTrue($random <= $b);
+    }
 }


### PR DESCRIPTION
Now you can sample from uniform and categorical discrete distributions by calling `rand()`.

Examples:


```php
$uniform = new Uniform(10, 20);
$random = $uniform->rand();


$categorical   = new Categorical(3, ['a' => 0.2, 'b' => 0.5, 'c' => 0.3]);
$random  = $categorical->rand(); // $random is 'a' or 'b' or 'c'
```