### PR TITLE
Fix php8.4 deprecated notices

### DIFF
--- a/src/Functions/BaseEncoderDecoder.php
+++ b/src/Functions/BaseEncoderDecoder.php
@@ -91,7 +91,7 @@ class BaseEncoderDecoder
      *
      * @throws Exception\BadParameterException if the string is empty or base is greater than 256
      */
-    public static function createArbitraryInteger(string $number, int $base, string $offset = null): ArbitraryInteger
+    public static function createArbitraryInteger(string $number, int $base, ?string $offset = null): ArbitraryInteger
     {
         if ($number == '') {
             throw new Exception\BadParameterException("String cannot be empty.");

--- a/src/LinearAlgebra/MatrixFactory.php
+++ b/src/LinearAlgebra/MatrixFactory.php
@@ -425,7 +425,7 @@ class MatrixFactory
      * @throws Exception\MathException
      * @throws Exception\OutOfBoundsException if m, n, or k are < 0; if k >= n
      */
-    public static function eye(int $m, int $n, int $k, float $x = null): NumericMatrix
+    public static function eye(int $m, int $n, int $k, ?float $x = null): NumericMatrix
     {
         if ($n < 0 || $m < 0 || $k < 0) {
             throw new Exception\OutOfBoundsException("m, n and k must be ≥ 0. m = $m, n = $n, k = $k");

--- a/src/LinearAlgebra/NumericMatrix.php
+++ b/src/LinearAlgebra/NumericMatrix.php
@@ -3029,7 +3029,7 @@ class NumericMatrix extends Matrix
      * @throws Exception\MatrixException if method is not a valid eigenvalue method
      * @throws Exception\MathException
      */
-    public function eigenvalues(string $method = null): array
+    public function eigenvalues(?string $method = null): array
     {
         if (!$this->isSquare()) {
             throw new Exception\MatrixException('Eigenvalues can only be calculated on square matrices');
@@ -3068,7 +3068,7 @@ class NumericMatrix extends Matrix
      * @throws Exception\MatrixException if method is not a valid eigenvalue method
      * @throws Exception\MathException
      */
-    public function eigenvectors(string $method = null): NumericMatrix
+    public function eigenvectors(?string $method = null): NumericMatrix
     {
         if ($method === null) {
             return Eigenvector::eigenvectors($this, $this->eigenvalues());

--- a/src/Probability/Combinatorics.php
+++ b/src/Probability/Combinatorics.php
@@ -228,7 +228,7 @@ class Combinatorics
      *
      * @throws Exception\OutOfBoundsException if n is negative or k is larger than n
      */
-    public static function permutations(int $n, int $k = null): float
+    public static function permutations(int $n, ?int $k = null): float
     {
         if ($n < 0) {
             throw new Exception\OutOfBoundsException('Cannot compute negative permutations.');

--- a/src/Statistics/Distance.php
+++ b/src/Statistics/Distance.php
@@ -191,7 +191,7 @@ class Distance
      * @throws Exception\OutOfBoundsException
      * @throws Exception\VectorException
      */
-    public static function mahalanobis(NumericMatrix $x, NumericMatrix $data, NumericMatrix $y = null): float
+    public static function mahalanobis(NumericMatrix $x, NumericMatrix $data, ?NumericMatrix $y = null): float
     {
         $Centroid = $data->rowMeans()->asColumnMatrix();
         $Nx       = $x->getN();

--- a/src/Statistics/KernelDensityEstimation.php
+++ b/src/Statistics/KernelDensityEstimation.php
@@ -49,7 +49,7 @@ class KernelDensityEstimation
      * @throws Exception\OutOfBoundsException h ≤ 0
      * @throws Exception\BadParameterException
      */
-    public function __construct(array $data, float $h = null, $kernel = null)
+    public function __construct(array $data, ?float $h = null, $kernel = null)
     {
         $this->n = \count($data);
         if ($this->n === 0) {
@@ -68,7 +68,7 @@ class KernelDensityEstimation
      *
      * @throws Exception\OutOfBoundsException if h ≤ 0
      */
-    public function setBandwidth(float $h = null): void
+    public function setBandwidth(?float $h = null): void
     {
         if ($h === null) {
             $this->h = $this->getDefaultBandwidth();

--- a/src/Statistics/Multivariate/PCA.php
+++ b/src/Statistics/Multivariate/PCA.php
@@ -106,7 +106,7 @@ class PCA
      *
      * @throws Exception\MathException
      */
-    public function standardizeData(NumericMatrix $new_data = null): NumericMatrix
+    public function standardizeData(?NumericMatrix $new_data = null): NumericMatrix
     {
         if ($new_data === null) {
             $X = $this->data;
@@ -164,7 +164,7 @@ class PCA
      *
      * @throws Exception\MathException
      */
-    public function getScores(NumericMatrix $new_data = null): NumericMatrix
+    public function getScores(?NumericMatrix $new_data = null): NumericMatrix
     {
         if ($new_data === null) {
             $scaled_data = $this->data;
@@ -220,7 +220,7 @@ class PCA
      *
      * @throws Exception\MathException
      */
-    public function getQResiduals(NumericMatrix $new_data = null): NumericMatrix
+    public function getQResiduals(?NumericMatrix $new_data = null): NumericMatrix
     {
         $vars = $this->data->getN();
 
@@ -265,7 +265,7 @@ class PCA
      *
      * @throws Exception\MathException
      */
-    public function getT2Distances(NumericMatrix $new_data = null): NumericMatrix
+    public function getT2Distances(?NumericMatrix $new_data = null): NumericMatrix
     {
         $vars = $this->data->getN();
 


### PR DESCRIPTION
Fixes

```
PHP Deprecated:  MathPHP\Statistics\Multivariate\PCA::standardizeData(): Implicitly marking parameter $new_data as nullable is deprecated, the explicit nullable type must be used instead in ./src/Statistics/Multivariate/PCA.php on line 109
PHP Deprecated:  MathPHP\Statistics\Multivariate\PCA::getScores(): Implicitly marking parameter $new_data as nullable is deprecated, the explicit nullable type must be used instead in ./src/Statistics/Multivariate/PCA.php on line 167
PHP Deprecated:  MathPHP\Statistics\Multivariate\PCA::getQResiduals(): Implicitly marking parameter $new_data as nullable is deprecated, the explicit nullable type must be used instead in ./src/Statistics/Multivariate/PCA.php on line 223
PHP Deprecated:  MathPHP\Statistics\Multivariate\PCA::getT2Distances(): Implicitly marking parameter $new_data as nullable is deprecated, the explicit nullable type must be used instead in ./src/Statistics/Multivariate/PCA.php on line 268
PHP Deprecated:  MathPHP\Statistics\KernelDensityEstimation::__construct(): Implicitly marking parameter $h as nullable is deprecated, the explicit nullable type must be used instead in ./src/Statistics/KernelDensityEstimation.php on line 52
PHP Deprecated:  MathPHP\Statistics\KernelDensityEstimation::setBandwidth(): Implicitly marking parameter $h as nullable is deprecated, the explicit nullable type must be used instead in ./src/Statistics/KernelDensityEstimation.php on line 71
PHP Deprecated:  MathPHP\Statistics\Distance::mahalanobis(): Implicitly marking parameter $y as nullable is deprecated, the explicit nullable type must be used instead in ./src/Statistics/Distance.php on line 194
PHP Deprecated:  MathPHP\Probability\Combinatorics::permutations(): Implicitly marking parameter $k as nullable is deprecated, the explicit nullable type must be used instead in ./src/Probability/Combinatorics.php on line 231
PHP Deprecated:  MathPHP\Functions\BaseEncoderDecoder::createArbitraryInteger(): Implicitly marking parameter $offset as nullable is deprecated, the explicit nullable type must be used instead in ./src/Functions/BaseEncoderDecoder.php on line 94
PHP Deprecated:  MathPHP\LinearAlgebra\NumericMatrix::eigenvalues(): Implicitly marking parameter $method as nullable is deprecated, the explicit nullable type must be used instead in ./src/LinearAlgebra/NumericMatrix.php on line 3032
PHP Deprecated:  MathPHP\LinearAlgebra\NumericMatrix::eigenvectors(): Implicitly marking parameter $method as nullable is deprecated, the explicit nullable type must be used instead in ./src/LinearAlgebra/NumericMatrix.php on line 3071
PHP Deprecated:  MathPHP\LinearAlgebra\MatrixFactory::eye(): Implicitly marking parameter $x as nullable is deprecated, the explicit nullable type must be used instead in ./src/LinearAlgebra/MatrixFactory.php on line 428
```